### PR TITLE
Replace ReactiveList with SourceList

### DIFF
--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -5,12 +5,14 @@
 // </copyright>
 
 using System;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using ReactiveUI.Legacy;
+using DynamicData;
+using DynamicData.Aggregation;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.States;
@@ -29,32 +31,16 @@ namespace ReactiveUI.Validation.Contexts
     /// </remarks>
     public class ValidationContext : ReactiveObject, IDisposable, IValidationComponent
     {
-        /// <summary>
-        /// Backing field for the current validation state.
-        /// </summary>
-        private readonly ObservableAsPropertyHelper<bool> _isValid;
-
-        private readonly IConnectableObservable<bool> _validationConnectable;
-
-        /// <summary>
-        /// The list of current validations.
-        /// </summary>
-        private readonly ReactiveList<IValidationComponent> _validations = new ReactiveList<IValidationComponent>();
-
+        private readonly SourceList<IValidationComponent> _validationSource = new SourceList<IValidationComponent>();
         private readonly ReplaySubject<ValidationState> _validationStatusChange = new ReplaySubject<ValidationState>(1);
-
-        /// <summary>
-        /// Backing field for the validation summary.
-        /// </summary>
-        private readonly ObservableAsPropertyHelper<ValidationText> _validationText;
-
-        /// <summary>
-        /// Subject for validity of the context.
-        /// </summary>
         private readonly ReplaySubject<bool> _validSubject = new ReplaySubject<bool>(1);
 
-        private CompositeDisposable _disposables = new CompositeDisposable();
+        private readonly IConnectableObservable<bool> _validationConnectable;
+        private readonly ReadOnlyObservableCollection<IValidationComponent> _validations;
+        private readonly ObservableAsPropertyHelper<ValidationText> _validationText;
+        private readonly ObservableAsPropertyHelper<bool> _isValid;
 
+        private CompositeDisposable _disposables = new CompositeDisposable();
         private bool _isActive;
 
         /// <summary>
@@ -62,25 +48,44 @@ namespace ReactiveUI.Validation.Contexts
         /// </summary>
         public ValidationContext()
         {
-            // Publish the current validation state
-            _disposables.Add(_validSubject.StartWith(true).ToProperty(this, m => m.IsValid, out _isValid));
+            // Publish the current validation state.
+            _disposables.Add(_validSubject
+                .StartWith(true)
+                .ToProperty(this, m => m.IsValid, out _isValid));
 
-            // When a change occurs in the validation state, publish the updated validation text
-            _disposables.Add(_validSubject.StartWith(true).Select(v => BuildText())
+            // When a change occurs in the validation state, publish the updated validation text.
+            _disposables.Add(_validSubject
+                .StartWith(true)
+                .Select(_ => BuildText())
                 .ToProperty(this, m => m.Text, out _validationText, new ValidationText()));
 
-            // Publish the current validation state
-            _disposables.Add(_validSubject.Select(v => new ValidationState(IsValid, BuildText(), this))
-                .Do(vc => _validationStatusChange.OnNext(vc)).Subscribe());
+            // Publish the current validation state.
+            _disposables.Add(_validSubject
+                .Select(_ => new ValidationState(IsValid, BuildText(), this))
+                .Do(vc => _validationStatusChange.OnNext(vc))
+                .Subscribe());
 
             // Observe the defined validations and whenever there is a change publish the current validation state.
-            _validationConnectable = _validations.CountChanged.StartWith(0)
+            _validationConnectable = _validationSource
+                .Connect()
+                .CountChanged()
+                .Count()
+                .StartWith(0)
                 .Select(_ =>
                     _validations
-                        .Select(v => v.ValidationStatusChange).Merge()
-                        .Select(o => Unit.Default).StartWith(Unit.Default))
+                        .Select(v => v.ValidationStatusChange)
+                        .Merge()
+                        .Select(__ => Unit.Default)
+                        .StartWith(Unit.Default))
                 .Switch()
-                .Select(_ => GetIsValid()).Multicast(_validSubject);
+                .Select(_ => GetIsValid())
+                .Multicast(_validSubject);
+
+            // Connect SourceList to read only observable collection.
+            _validationSource
+                .Connect()
+                .Bind(out _validations)
+                .Subscribe();
         }
 
         /// <summary>
@@ -98,7 +103,7 @@ namespace ReactiveUI.Validation.Contexts
         /// <summary>
         /// Gets get the list of validations.
         /// </summary>
-        public IReadOnlyReactiveList<IValidationComponent> Validations => _validations;
+        public ReadOnlyObservableCollection<IValidationComponent> Validations => _validations;
 
         /// <inheritdoc />
         public bool IsValid
@@ -136,7 +141,7 @@ namespace ReactiveUI.Validation.Contexts
         /// <param name="validation">Validation component to be added into the collection.</param>
         public void Add(IValidationComponent validation)
         {
-            _validations.Add(validation);
+            _validationSource.Add(validation);
         }
 
         /// <summary>
@@ -145,8 +150,7 @@ namespace ReactiveUI.Validation.Contexts
         /// <returns>Returns true if the <see cref="ValidationContext"/> is valid, otherwise false.</returns>
         public bool GetIsValid()
         {
-            var isValid = _validations.Count == 0 || _validations.All(v => v.IsValid);
-            return isValid;
+            return _validations.Count == 0 || _validations.All(v => v.IsValid);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Removes the dependency on `ReactiveUI.Legacy` namespace.

**What is the current behavior? (You can also link to an open issue here)**

ReactiveUI.Validation uses `ReactiveList` which is now obsolete.

**What is the new behavior (if this is a feature change)?**

ReactiveUI.Validation uses DynamicData `SourceList<T>` now.

**What might this PR break?**

Probably nothing, let's see CI checks!