### PR TITLE
housekeeping: Add Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![NuGet Stats](https://img.shields.io/nuget/v/reactiveui.validation.svg)](https://www.nuget.org/packages/reactiveui.validation) [![Build Status](https://dev.azure.com/dotnet/ReactiveUI/_apis/build/status/ReactiveUI.Validation-CI)](https://dev.azure.com/dotnet/ReactiveUI/_build/latest?definitionId=11)  [![Code Coverage](https://codecov.io/gh/reactiveui/ReactiveUI.Validation/branch/master/graph/badge.svg)](https://codecov.io/gh/reactiveui/ReactiveUI.Validation)
+
 # ReactiveUI.Validation
 
 Validation for ReactiveUI based solutions, functioning in a reactive way. This repository is based on [jcmm33's Vistian.Reactive.Validation](https://github.com/jcmm33/ReactiveUI.Validation).


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Added codecov, azure pipelines and nuget badges.

What is the current behavior? (You can also link to an open issue here)

There are no badges in README.md now!

What is the new behavior (if this is a feature change)?

Badges are present.

What might this PR break?

Nothing.