### PR TITLE
Fix #16: Null reference with lambdas

### DIFF
--- a/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
@@ -136,7 +136,6 @@ namespace ReactiveUI.Validation.Tests
             // View bindings
             view.Bind(view.ViewModel, vm => vm.Name, v => v.NameLabel);
 
-            // TODO: add Assert.Throws to custom exception wrapping this call
             // View validations bindings
             var ex = Assert.Throws<MultipleValidationNotSupportedException>(() =>
             {
@@ -153,6 +152,40 @@ namespace ReactiveUI.Validation.Tests
             var expectedError =
                 $"Property {nameof(viewModel.Name)} has more than one validation rule associated. Consider using {nameof(ValidationBindingEx)} methods.";
             Assert.Equal(expectedError, ex.Message);
+        }
+
+        /// <summary>
+        /// Verifies that validations registered with different lambda names are retrieved successfully.
+        /// </summary>
+        [Fact]
+        public void RegisterValidationsWithDifferentLambdaNameWorksTest()
+        {
+            const string validName = "valid";
+            const int minimumLength = 5;
+
+            var viewModel = new TestViewModel { Name = validName };
+            var view = new TestView(viewModel);
+
+            var firstValidation = new BasePropertyValidation<TestViewModel, string>(
+                viewModel,
+                viewModelProperty => viewModelProperty.Name,
+                s => !string.IsNullOrEmpty(s),
+                s => $"Name {s} isn't valid");
+
+            // Add validations
+            viewModel.ValidationContext.Add(firstValidation);
+
+            // View bindings
+            view.Bind(view.ViewModel, vm => vm.Name, v => v.NameLabel);
+
+            // This was throwing exception due to naming problems with lambdas expressions
+            view.BindValidation(
+                view.ViewModel,
+                vm => vm.Name,
+                v => v.NameErrorLabel);
+
+            Assert.True(viewModel.ValidationContext.IsValid);
+            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
         }
     }
 }

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -120,7 +120,7 @@ namespace ReactiveUI.Validation.Components
         /// <returns>Returns true if it contains the property, otherwise false.</returns>
         public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
         {
-            var propertyName = property.Body.ToString();
+            var propertyName = property.Body.GetMemberInfo().ToString();
 
             return exclusively
                 ? _propertyNames.Contains(propertyName) && _propertyNames.Count == 1
@@ -134,7 +134,7 @@ namespace ReactiveUI.Validation.Components
         /// <param name="property">ViewModel property.</param>
         protected void AddProperty<TProp>(Expression<Func<TViewModel, TProp>> property)
         {
-            var propertyName = property.Body.ToString();
+            var propertyName = property.Body.GetMemberInfo().ToString();
             _propertyNames.Add(propertyName);
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix null reference when registering validations with different lambda body name.

**What is the current behavior? (You can also link to an open issue here)**
If you register a validation with "viewModel => viewModel.Name" and in the view you register with "vm => vm.Name", it will throw an Exception due that is comparing the full body name.

See bug: https://github.com/reactiveui/ReactiveUI.Validation/issues/16

**What might this PR break?**
Nothing.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)