### PR TITLE
Use Space char as default delimiter

### DIFF
--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.cs
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.cs
@@ -4,13 +4,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using PublicApiGenerator;
 using ReactiveUI.Validation.ValidationBindings;
@@ -18,7 +16,7 @@ using Shouldly;
 using Splat;
 using Xunit;
 
-namespace Sextant.Tests
+namespace ReactiveUI.Validation.Tests.API
 {
     /// <summary>
     /// Tests to make sure that the API matches the approved ones.

--- a/src/ReactiveUI.Validation.Tests/Models/TestView.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/TestView.cs
@@ -30,6 +30,11 @@ namespace ReactiveUI.Validation.Tests.Models
         public string NameLabel { get; set; }
 
         /// <summary>
+        /// Gets or sets the Name2 Label which emulates a Text property (eg. Entry in Xamarin.Forms).
+        /// </summary>
+        public string Name2Label { get; set; }
+
+        /// <summary>
         /// Gets or sets the NameError Label which emulates a Text property (eg. Entry in Xamarin.Forms).
         /// </summary>
         public string NameErrorLabel { get; set; }

--- a/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
@@ -161,8 +161,6 @@ namespace ReactiveUI.Validation.Tests
         public void RegisterValidationsWithDifferentLambdaNameWorksTest()
         {
             const string validName = "valid";
-            const int minimumLength = 5;
-
             var viewModel = new TestViewModel { Name = validName };
             var view = new TestView(viewModel);
 
@@ -185,7 +183,41 @@ namespace ReactiveUI.Validation.Tests
                 v => v.NameErrorLabel);
 
             Assert.True(viewModel.ValidationContext.IsValid);
-            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.Single(viewModel.ValidationContext.Validations);
+        }
+
+        /// <summary>
+        /// Verifies that validation error messages get concatenated using white space.
+        /// </summary>
+        [Fact]
+        public void ValidationMessagesDefaultConcatenationTest()
+        {
+            var viewModel = new TestViewModel { Name = string.Empty };
+            var view = new TestView(viewModel);
+
+            var nameValidation = new BasePropertyValidation<TestViewModel, string>(
+                viewModel,
+                viewModelProperty => viewModelProperty.Name,
+                s => !string.IsNullOrEmpty(s),
+                "Name should not be empty.");
+
+            var name2Validation = new BasePropertyValidation<TestViewModel, string>(
+                viewModel,
+                viewModelProperty => viewModelProperty.Name2,
+                s => !string.IsNullOrEmpty(s),
+                "Name2 should not be empty.");
+
+            viewModel.ValidationContext.Add(nameValidation);
+            viewModel.ValidationContext.Add(name2Validation);
+
+            view.Bind(view.ViewModel, vm => vm.Name, v => v.NameLabel);
+            view.Bind(view.ViewModel, vm => vm.Name2, v => v.Name2Label);
+            view.BindValidation(view.ViewModel, v => v.NameErrorLabel);
+
+            Assert.False(viewModel.ValidationContext.IsValid);
+            Assert.Equal(2, viewModel.ValidationContext.Validations.Count);
+            Assert.NotEmpty(view.NameErrorLabel);
+            Assert.Equal("Name should not be empty. Name2 should not be empty.", view.NameErrorLabel);
         }
     }
 }

--- a/src/ReactiveUI.Validation/Formatters/SingleLineFormatter.cs
+++ b/src/ReactiveUI.Validation/Formatters/SingleLineFormatter.cs
@@ -29,7 +29,7 @@ namespace ReactiveUI.Validation.Formatters
         /// <summary>
         /// Gets the default formatter.
         /// </summary>
-        public static SingleLineFormatter Default { get; } = new SingleLineFormatter();
+        public static SingleLineFormatter Default { get; } = new SingleLineFormatter(" ");
 
         /// <summary>
         /// Formats the <see cref="ValidationText"/> into a single line text using the


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Now `SingleLineFormatter` uses the " " character by default for validation error messages concatenation. I think this behavior is what a new user would expect from the library.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Before, it just concatenated the error message texts. This caused the messages to be glued to each other.

![image](https://user-images.githubusercontent.com/6759207/57335176-7959bc80-712a-11e9-8c2a-6367137a7190.png)

**What is the new behavior?**
<!-- If this is a feature change -->

Now the messages are concatenated using the whitespace character. This can be easily overriden by passing a custom `SingleLineFormatter` to `BindValidation`, but probably using the whitespace character out-of-box will make the library more developer-friendly.

![image](https://user-images.githubusercontent.com/6759207/57335220-97bfb800-712a-11e9-9921-f4e661478a3e.png)

**What might this PR break?**

Sometimes when running unit tests locally I get the following exception thrown in random tests:

```
System.InvalidOperationException : Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at ReactiveUI.POCOObservableForProperty.GetNotificationForProperty(Object sender, Expression expression, String propertyName, Boolean beforeChanged) in D:\a\1\s\src\ReactiveUI\ObservableForProperty\POCOObservableForProperty.cs:line 39
   at ReactiveUI.ReactiveNotifyPropertyChangedMixin.NotifyForProperty(Object sender, Expression expression, Boolean beforeChange) in D:\a\1\s\src\ReactiveUI\Mixins\ReactiveNotifyPropertyChangedMixin.cs:line 206
   at ReactiveUI.ReactiveNotifyPropertyChangedMixin.NestedObservedChanges(Expression expression, IObservedChange`2 sourceChange, Boolean beforeChange) in D:\a\1\s\src\ReactiveUI\Mixins\ReactiveNotifyPropertyChangedMixin.cs:line 190
   at System.Reactive.Linq.ObservableImpl.Select`2.Selector._.OnNext(TSource value) in D:\a\1\s\Rx.NET\Source\src\System.Reactive\Linq\Observable\Select.cs:line 39
```

This seem to happen due to a race condition in unit tests harness. The dictionary in `POCOObservableForProperty` is not concurrent, probably we should fix that:
https://github.com/reactiveui/ReactiveUI/blob/eb53eee4bd1865b3a226ec468c0a344620349bee/src/ReactiveUI/ObservableForProperty/POCOObservableForProperty.cs#L21 
