### PR TITLE
Support INotifyDataErrorInfo, rename ISupportsValidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ namespace SampleApp.Activities
 For those platforms which support the `INotifyDataErrorInfo` interface, ReactiveUI.Validation provides a helper base class named `ReactiveValidationObject<TViewModel>`. The helper class implements both the `IValidatableViewModel` interface and the `INotifyDataErrorInfo` interface. It listens to any changes in the `ValidationContext` and invokes `INotifyDataErrorInfo` events. 
 
 ```cs
-public class IndeiTestViewModel : ReactiveValidationObject<IndeiTestViewModel>
+public class SampleViewModel : ReactiveValidationObject<SampleViewModel>
 {
     [Reactive]
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 
-    public IndeiTestViewModel()
+    public SampleViewModel()
     {
         this.ValidationRule(
             x => x.Name, 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ Install the following package into you class library and platform-specific proje
 
 ## How to use
 
-* For ViewModels which need validation, implement `ISupportsValidation`.
+* For ViewModels which need validation, implement `IValidatableViewModel`.
 * Add validation rules to the ViewModel.
 * Bind to the validation rules in the View.
 
 ## Example
 
-1. Decorate existing ViewModel with `ISupportsValidation`, which has a single member, `ValidationContext`. The ValidationContext contains all of the functionality surrounding the validation of the ViewModel. Most access to the specification of validation rules is performed through extension methods on the ISupportsValidation interface. Then, add validation to the ViewModel.
+1. Decorate existing ViewModel with `IValidatableViewModel`, which has a single member, `ValidationContext`. The ValidationContext contains all of the functionality surrounding the validation of the ViewModel. Most access to the specification of validation rules is performed through extension methods on the `IValidatableViewModel` interface. Then, add validation to the ViewModel.
 
 ```csharp
-public class SampleViewModel : ReactiveObject, ISupportsValidation
+public class SampleViewModel : ReactiveObject, IValidatableViewModel
 {
     public SampleViewModel()
     {
-        // Creates the validation for the Name property
+        // Creates the validation for the Name property.
         this.ValidationRule(
             viewModel => viewModel.Name,
             name => !string.IsNullOrWhiteSpace(name),
@@ -69,7 +69,7 @@ public class SampleView : ReactiveContentPage<SampleViewModel>
                 .DisposeWith(disposables);
 
             // Bind any validations which reference the Name property 
-            // to the text of the NameError UI control
+            // to the text of the NameError UI control.
             this.BindValidation(ViewModel, vm => vm.Name, view => view.NameError.Text)
                 .DisposeWith(disposables);
         });
@@ -114,6 +114,28 @@ namespace SampleApp.Activities
     }
 }
 ```
+
+## INotifyDataErrorInfo Support
+
+For those platforms which support the `INotifyDataErrorInfo` interface, ReactiveUI.Validation provides a helper base class named `ReactiveValidationObject<TViewModel>`. The helper class implements both the `IValidatableViewModel` interface and the `INotifyDataErrorInfo` interface. It listens to any changes in the `ValidationContext` and invokes `INotifyDataErrorInfo` events. 
+
+```cs
+public class IndeiTestViewModel : ReactiveValidationObject<IndeiTestViewModel>
+{
+    [Reactive]
+    public string Name { get; set; }
+
+    public IndeiTestViewModel()
+    {
+        this.ValidationRule(
+            x => x.Name, 
+            name => !string.IsNullOrWhiteSpace(name),
+            "Name shouldn't be empty.");
+    }
+}
+```
+
+> **Note** The `Reactive` attribute is from the [ReactiveUI.Fody](https://reactiveui.net/docs/handbook/view-models/boilerplate-code) NuGet package.
 
 ## Capabilities
 

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace ReactiveUI.Validation.Abstractions
 {
-    public interface ISupportsValidation
+    public interface IValidatableViewModel
     {
         ReactiveUI.Validation.Contexts.ValidationContext ValidationContext { get; }
     }
@@ -50,6 +50,7 @@ namespace ReactiveUI.Validation.Components
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = False) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = False) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         protected abstract System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable();
@@ -104,13 +105,13 @@ namespace ReactiveUI.Validation.Extensions
     public class static SupportsValidationExtensions
     {
         public static System.IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModelProp, bool> isPropertyValid, string message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModelProp, bool> isPropertyValid, System.Func<TViewModelProp, string> message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
     public class static ValidationContextExtensions
     {
@@ -129,16 +130,16 @@ namespace ReactiveUI.Validation.Extensions
         public static System.IDisposable BindToDirect<TTarget, TValue>(System.IObservable<TValue> @this, TTarget target, System.Linq.Expressions.Expression viewExpression) { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
 }
 namespace ReactiveUI.Validation.Formatters.Abstractions
@@ -159,6 +160,14 @@ namespace ReactiveUI.Validation.Formatters
 }
 namespace ReactiveUI.Validation.Helpers
 {
+    public abstract class ReactiveValidationObject<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo
+    {
+        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler scheduler = null) { }
+        public bool HasErrors { get; }
+        public ReactiveUI.Validation.Contexts.ValidationContext ValidationContext { get; }
+        public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs> ErrorsChanged;
+        public virtual System.Collections.IEnumerable GetErrors(string propertyName) { }
+    }
     public class ValidationHelper : ReactiveUI.ReactiveObject, System.IDisposable
     {
         public ValidationHelper(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
@@ -234,31 +243,31 @@ namespace ReactiveUI.Validation.ValidationBindings
         public void Dispose() { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string> formatter = null, bool strict = True)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<ReactiveUI.Validation.States.ValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter = null, bool strict = True)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string> formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Action<ReactiveUI.Validation.States.ValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TOut>(TView view, System.Action<TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string> formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
     public sealed class ValidationBindingEx : ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding, System.IDisposable
     {
         public void Dispose() { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string> formatter = null, bool strict = True)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>, System.Collections.Generic.IList<TOut>> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter = null, bool strict = True)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp2.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp2.1.approved.txt
@@ -1,7 +1,7 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace ReactiveUI.Validation.Abstractions
 {
-    public interface ISupportsValidation
+    public interface IValidatableViewModel
     {
         ReactiveUI.Validation.Contexts.ValidationContext ValidationContext { get; }
     }
@@ -50,6 +50,7 @@ namespace ReactiveUI.Validation.Components
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = False) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = False) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         protected abstract System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable();
@@ -104,13 +105,13 @@ namespace ReactiveUI.Validation.Extensions
     public class static SupportsValidationExtensions
     {
         public static System.IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModelProp, bool> isPropertyValid, string message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModelProp, bool> isPropertyValid, System.Func<TViewModelProp, string> message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
     public class static ValidationContextExtensions
     {
@@ -129,16 +130,16 @@ namespace ReactiveUI.Validation.Extensions
         public static System.IDisposable BindToDirect<TTarget, TValue>(System.IObservable<TValue> @this, TTarget target, System.Linq.Expressions.Expression viewExpression) { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
 }
 namespace ReactiveUI.Validation.Formatters.Abstractions
@@ -159,6 +160,14 @@ namespace ReactiveUI.Validation.Formatters
 }
 namespace ReactiveUI.Validation.Helpers
 {
+    public abstract class ReactiveValidationObject<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo
+    {
+        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler scheduler = null) { }
+        public bool HasErrors { get; }
+        public ReactiveUI.Validation.Contexts.ValidationContext ValidationContext { get; }
+        public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs> ErrorsChanged;
+        public virtual System.Collections.IEnumerable GetErrors(string propertyName) { }
+    }
     public class ValidationHelper : ReactiveUI.ReactiveObject, System.IDisposable
     {
         public ValidationHelper(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
@@ -234,31 +243,31 @@ namespace ReactiveUI.Validation.ValidationBindings
         public void Dispose() { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string> formatter = null, bool strict = True)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<ReactiveUI.Validation.States.ValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter = null, bool strict = True)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string> formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Action<ReactiveUI.Validation.States.ValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TOut>(TView view, System.Action<TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string> formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
     public sealed class ValidationBindingEx : ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding, System.IDisposable
     {
         public void Dispose() { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string> formatter = null, bool strict = True)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>, System.Collections.Generic.IList<TOut>> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter = null, bool strict = True)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.ISupportsValidation { }
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/Models/IndeiTestView.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/IndeiTestView.cs
@@ -6,7 +6,7 @@ namespace ReactiveUI.Validation.Tests.Models
     public class IndeiTestView : IViewFor<IndeiTestViewModel>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="TestView"/> class.
+        /// Initializes a new instance of the <see cref="IndeiTestView"/> class.
         /// </summary>
         /// <param name="viewModel">ViewModel instance of type <see cref="TestViewModel"/>.</param>
         public IndeiTestView(IndeiTestViewModel viewModel)

--- a/src/ReactiveUI.Validation.Tests/Models/IndeiTestView.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/IndeiTestView.cs
@@ -1,0 +1,37 @@
+namespace ReactiveUI.Validation.Tests.Models
+{
+    /// <summary>
+    /// Mocked View for INotifyDataErrorInfo testing.
+    /// </summary>
+    public class IndeiTestView : IViewFor<IndeiTestViewModel>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestView"/> class.
+        /// </summary>
+        /// <param name="viewModel">ViewModel instance of type <see cref="TestViewModel"/>.</param>
+        public IndeiTestView(IndeiTestViewModel viewModel)
+        {
+            ViewModel = viewModel;
+        }
+
+        /// <inheritdoc/>
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = value as IndeiTestViewModel;
+        }
+
+        /// <inheritdoc/>
+        public IndeiTestViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Name Label which emulates a Text property (eg. Entry in Xamarin.Forms).
+        /// </summary>
+        public string NameLabel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NameError Label which emulates a Text property (eg. Entry in Xamarin.Forms).
+        /// </summary>
+        public string NameErrorLabel { get; set; }
+    }
+}

--- a/src/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
@@ -10,8 +10,14 @@ namespace ReactiveUI.Validation.Tests.Models
     {
         private string _name;
 
-        public IndeiTestViewModel() : base(ImmediateScheduler.Instance) { }
-        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IndeiTestViewModel"/> class.
+        /// </summary>
+        public IndeiTestViewModel()
+            : base(ImmediateScheduler.Instance)
+        {
+        }
+
         /// <summary>
         /// Gets or sets get the Name.
         /// </summary>

--- a/src/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
@@ -1,0 +1,24 @@
+using System.Reactive.Concurrency;
+using ReactiveUI.Validation.Helpers;
+
+namespace ReactiveUI.Validation.Tests.Models
+{
+    /// <summary>
+    /// Mocked ViewModel for INotifyDataErrorInfo testing.
+    /// </summary>
+    public class IndeiTestViewModel : ReactiveValidationObject<IndeiTestViewModel>
+    {
+        private string _name;
+
+        public IndeiTestViewModel() : base(ImmediateScheduler.Instance) { }
+        
+        /// <summary>
+        /// Gets or sets get the Name.
+        /// </summary>
+        public string Name
+        {
+            get => _name;
+            set => this.RaiseAndSetIfChanged(ref _name, value);
+        }
+    }
+}

--- a/src/ReactiveUI.Validation.Tests/Models/TestViewModel.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/TestViewModel.cs
@@ -8,7 +8,7 @@ namespace ReactiveUI.Validation.Tests.Models
     /// <summary>
     /// Mocked ViewModel.
     /// </summary>
-    public class TestViewModel : ReactiveObject, ISupportsValidation
+    public class TestViewModel : ReactiveObject, IValidatableViewModel
     {
         private string _name;
         private string _name2;

--- a/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
+++ b/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.Validation.Tests
     public class NotifyDataErrorInfoTests
     {
         private const string NameShouldNotBeEmptyMessage = "Name shouldn't be empty.";
-        
+
         /// <summary>
         /// Verifies that the ErrorsChanged event fires on ViewModel initialization.
         /// </summary>
@@ -22,7 +22,7 @@ namespace ReactiveUI.Validation.Tests
         {
             var viewModel = new IndeiTestViewModel();
             var view = new IndeiTestView(viewModel);
-            
+
             var firstValidation = new BasePropertyValidation<IndeiTestViewModel, string>(
                 viewModel,
                 vm => vm.Name,
@@ -35,9 +35,9 @@ namespace ReactiveUI.Validation.Tests
 
             // Verify validation context behavior.
             Assert.False(viewModel.ValidationContext.IsValid);
-            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.Single(viewModel.ValidationContext.Validations);
             Assert.Equal(NameShouldNotBeEmptyMessage, view.NameErrorLabel);
-            
+
             // Verify INotifyDataErrorInfo behavior.
             Assert.True(viewModel.HasErrors);
             Assert.Equal(NameShouldNotBeEmptyMessage, viewModel.GetErrors("Name").Cast<string>().First());
@@ -52,40 +52,40 @@ namespace ReactiveUI.Validation.Tests
         {
             var viewModel = new IndeiTestViewModel();
             var view = new IndeiTestView(viewModel);
-            
+
             var firstValidation = new BasePropertyValidation<IndeiTestViewModel, string>(
                 viewModel,
                 vm => vm.Name,
                 s => !string.IsNullOrEmpty(s),
                 NameShouldNotBeEmptyMessage);
-            
+
             viewModel.ValidationContext.Add(firstValidation);
             view.Bind(view.ViewModel, vm => vm.Name, v => v.NameLabel);
             view.BindValidationEx(view.ViewModel, vm => vm.Name, v => v.NameErrorLabel);
-            
+
             // Verify the initial state.
             Assert.True(viewModel.HasErrors);
             Assert.False(viewModel.ValidationContext.IsValid);
-            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.Single(viewModel.ValidationContext.Validations);
             Assert.Equal(NameShouldNotBeEmptyMessage, viewModel.GetErrors("Name").Cast<string>().First());
             Assert.Equal(NameShouldNotBeEmptyMessage, view.NameErrorLabel);
 
             // Send INotifyPropertyChanged.
             viewModel.Name = "JoJo";
-            
+
             // Verify the changed state.
             Assert.False(viewModel.HasErrors);
             Assert.True(viewModel.ValidationContext.IsValid);
-            Assert.Equal(0, viewModel.GetErrors("Name").Cast<string>().Count());
+            Assert.Empty(viewModel.GetErrors("Name").Cast<string>());
             Assert.Empty(view.NameErrorLabel);
 
             // Send INotifyPropertyChanged.
             viewModel.Name = string.Empty;
-            
+
             // Verify the changed state.
             Assert.True(viewModel.HasErrors);
             Assert.False(viewModel.ValidationContext.IsValid);
-            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.Single(viewModel.ValidationContext.Validations);
             Assert.Equal(NameShouldNotBeEmptyMessage, viewModel.GetErrors("Name").Cast<string>().First());
             Assert.Equal(NameShouldNotBeEmptyMessage, view.NameErrorLabel);
         }
@@ -97,10 +97,10 @@ namespace ReactiveUI.Validation.Tests
         public void ShouldFireErrorsChangedEventWhenValidationStateChanges()
         {
             var viewModel = new IndeiTestViewModel();
-            
+
             DataErrorsChangedEventArgs arguments = null;
             viewModel.ErrorsChanged += (sender, args) => arguments = args;
-            
+
             var firstValidation = new BasePropertyValidation<IndeiTestViewModel, string>(
                 viewModel,
                 vm => vm.Name,
@@ -108,17 +108,17 @@ namespace ReactiveUI.Validation.Tests
                 NameShouldNotBeEmptyMessage);
 
             viewModel.ValidationContext.Add(firstValidation);
-            
+
             Assert.True(viewModel.HasErrors);
             Assert.False(viewModel.ValidationContext.IsValid);
-            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
-            Assert.Equal(1, viewModel.GetErrors("Name").Cast<string>().Count());
+            Assert.Single(viewModel.ValidationContext.Validations);
+            Assert.Single(viewModel.GetErrors("Name").Cast<string>());
             Assert.Null(arguments);
 
             viewModel.Name = "JoJo";
-            
+
             Assert.False(viewModel.HasErrors);
-            Assert.Equal(0, viewModel.GetErrors("Name").Cast<string>().Count());
+            Assert.Empty(viewModel.GetErrors("Name").Cast<string>());
             Assert.NotNull(arguments);
             Assert.Equal("Name", arguments.PropertyName);
         }

--- a/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
+++ b/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
@@ -1,0 +1,126 @@
+using System.ComponentModel;
+using System.Linq;
+using ReactiveUI.Validation.Components;
+using ReactiveUI.Validation.Extensions;
+using ReactiveUI.Validation.Tests.Models;
+using Xunit;
+
+namespace ReactiveUI.Validation.Tests
+{
+    /// <summary>
+    /// Tests for INotifyDataErrorInfo support.
+    /// </summary>
+    public class NotifyDataErrorInfoTests
+    {
+        private const string NameShouldNotBeEmptyMessage = "Name shouldn't be empty.";
+        
+        /// <summary>
+        /// Verifies that the ErrorsChanged event fires on ViewModel initialization.
+        /// </summary>
+        [Fact]
+        public void ShouldMarkPropertiesAsInvalidOnInit()
+        {
+            var viewModel = new IndeiTestViewModel();
+            var view = new IndeiTestView(viewModel);
+            
+            var firstValidation = new BasePropertyValidation<IndeiTestViewModel, string>(
+                viewModel,
+                vm => vm.Name,
+                s => !string.IsNullOrEmpty(s),
+                NameShouldNotBeEmptyMessage);
+
+            viewModel.ValidationContext.Add(firstValidation);
+            view.Bind(view.ViewModel, vm => vm.Name, v => v.NameLabel);
+            view.BindValidationEx(view.ViewModel, vm => vm.Name, v => v.NameErrorLabel);
+
+            // Verify validation context behavior.
+            Assert.False(viewModel.ValidationContext.IsValid);
+            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.Equal(NameShouldNotBeEmptyMessage, view.NameErrorLabel);
+            
+            // Verify INotifyDataErrorInfo behavior.
+            Assert.True(viewModel.HasErrors);
+            Assert.Equal(NameShouldNotBeEmptyMessage, viewModel.GetErrors("Name").Cast<string>().First());
+        }
+
+        /// <summary>
+        /// Verifies that the view model listens to the INotifyPropertyChanged event
+        /// and sends INotifyDataErrorInfo notifications.
+        /// </summary>
+        [Fact]
+        public void ShouldSynchronizeNotifyDataErrorInfoWithValidationContext()
+        {
+            var viewModel = new IndeiTestViewModel();
+            var view = new IndeiTestView(viewModel);
+            
+            var firstValidation = new BasePropertyValidation<IndeiTestViewModel, string>(
+                viewModel,
+                vm => vm.Name,
+                s => !string.IsNullOrEmpty(s),
+                NameShouldNotBeEmptyMessage);
+            
+            viewModel.ValidationContext.Add(firstValidation);
+            view.Bind(view.ViewModel, vm => vm.Name, v => v.NameLabel);
+            view.BindValidationEx(view.ViewModel, vm => vm.Name, v => v.NameErrorLabel);
+            
+            // Verify the initial state.
+            Assert.True(viewModel.HasErrors);
+            Assert.False(viewModel.ValidationContext.IsValid);
+            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.Equal(NameShouldNotBeEmptyMessage, viewModel.GetErrors("Name").Cast<string>().First());
+            Assert.Equal(NameShouldNotBeEmptyMessage, view.NameErrorLabel);
+
+            // Send INotifyPropertyChanged.
+            viewModel.Name = "JoJo";
+            
+            // Verify the changed state.
+            Assert.False(viewModel.HasErrors);
+            Assert.True(viewModel.ValidationContext.IsValid);
+            Assert.Equal(0, viewModel.GetErrors("Name").Cast<string>().Count());
+            Assert.Empty(view.NameErrorLabel);
+
+            // Send INotifyPropertyChanged.
+            viewModel.Name = string.Empty;
+            
+            // Verify the changed state.
+            Assert.True(viewModel.HasErrors);
+            Assert.False(viewModel.ValidationContext.IsValid);
+            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.Equal(NameShouldNotBeEmptyMessage, viewModel.GetErrors("Name").Cast<string>().First());
+            Assert.Equal(NameShouldNotBeEmptyMessage, view.NameErrorLabel);
+        }
+
+        /// <summary>
+        /// The ErrorsChanged event should fire when properties change.
+        /// </summary>
+        [Fact]
+        public void ShouldFireErrorsChangedEventWhenValidationStateChanges()
+        {
+            var viewModel = new IndeiTestViewModel();
+            
+            DataErrorsChangedEventArgs arguments = null;
+            viewModel.ErrorsChanged += (sender, args) => arguments = args;
+            
+            var firstValidation = new BasePropertyValidation<IndeiTestViewModel, string>(
+                viewModel,
+                vm => vm.Name,
+                s => !string.IsNullOrEmpty(s),
+                NameShouldNotBeEmptyMessage);
+
+            viewModel.ValidationContext.Add(firstValidation);
+            
+            Assert.True(viewModel.HasErrors);
+            Assert.False(viewModel.ValidationContext.IsValid);
+            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.Equal(1, viewModel.GetErrors("Name").Cast<string>().Count());
+            Assert.Null(arguments);
+
+            viewModel.Name = "JoJo";
+            
+            Assert.False(viewModel.HasErrors);
+            Assert.Equal(0, viewModel.GetErrors("Name").Cast<string>().Count());
+            Assert.NotNull(arguments);
+            Assert.Equal("Name", arguments.PropertyName);
+        }
+    }
+}

--- a/src/ReactiveUI.Validation/Abstractions/IValidatableViewModel.cs
+++ b/src/ReactiveUI.Validation/Abstractions/IValidatableViewModel.cs
@@ -11,7 +11,7 @@ namespace ReactiveUI.Validation.Abstractions
     /// <summary>
     /// Interface used by view models to indicate they have a validation context.
     /// </summary>
-    public interface ISupportsValidation
+    public interface IValidatableViewModel
     {
         /// <summary>
         /// Gets get the validation context.

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -123,7 +123,7 @@ namespace ReactiveUI.Validation.Components
             var propertyName = property.Body.GetMemberInfo().ToString();
             return ContainsPropertyName(propertyName, exclusively);
         }
-        
+
         /// <summary>
         /// Determine if a property name is actually contained within this.
         /// </summary>

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -121,7 +121,17 @@ namespace ReactiveUI.Validation.Components
         public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
         {
             var propertyName = property.Body.GetMemberInfo().ToString();
-
+            return ContainsPropertyName(propertyName, exclusively);
+        }
+        
+        /// <summary>
+        /// Determine if a property name is actually contained within this.
+        /// </summary>
+        /// <param name="propertyName">ViewModel property name.</param>
+        /// <param name="exclusively">Indicates if the property to find is unique.</param>
+        /// <returns>Returns true if it contains the property, otherwise false.</returns>
+        public bool ContainsPropertyName(string propertyName, bool exclusively = false)
+        {
             return exclusively
                 ? _propertyNames.Contains(propertyName) && _propertyNames.Count == 1
                 : _propertyNames.Contains(propertyName);

--- a/src/ReactiveUI.Validation/Extensions/SupportsValidationExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/SupportsValidationExtensions.cs
@@ -13,7 +13,7 @@ using ReactiveUI.Validation.Helpers;
 namespace ReactiveUI.Validation.Extensions
 {
     /// <summary>
-    /// Extensions methods associated to <see cref="ISupportsValidation"/> instances.
+    /// Extensions methods associated to <see cref="IValidatableViewModel"/> instances.
     /// </summary>
     public static class SupportsValidationExtensions
     {
@@ -32,7 +32,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, TViewModelProp>> viewModelProperty,
             Func<TViewModelProp, bool> isPropertyValid,
             string message)
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             // We need to associate the ViewModel property
             // with something that can be easily looked up and bound to
@@ -62,7 +62,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, TViewModelProp>> viewModelProperty,
             Func<TViewModelProp, bool> isPropertyValid,
             Func<TViewModelProp, string> message)
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             // We need to associate the ViewModel property
             // with something that can be easily looked up and bound to
@@ -93,7 +93,7 @@ namespace ReactiveUI.Validation.Extensions
             this TViewModel viewModel,
             Func<TViewModel, IObservable<bool>> viewModelObservableProperty,
             Func<TViewModel, bool, string> messageFunc)
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             var validation =
                 new ModelObservableValidation<TViewModel>(viewModel, viewModelObservableProperty, messageFunc);
@@ -110,7 +110,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <param name="viewModel">ViewModel instance.</param>
         /// <returns>Returns true if the ValidationContext is valid, otherwise false.</returns>
         public static IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             return viewModel?.ValidationContext.Valid;
         }

--- a/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
@@ -42,7 +42,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             Expression<Func<TView, TViewProperty>> viewProperty)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             return ValidationBindingEx.ForProperty(view, viewModelProperty, viewProperty);
         }
@@ -70,7 +70,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             Expression<Func<TView, TViewProperty>> viewProperty)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             return ValidationBinding.ForProperty(view, viewModelProperty, viewProperty);
         }
@@ -94,7 +94,7 @@ namespace ReactiveUI.Validation.Extensions
             this TView view,
             TViewModel viewModel,
             Expression<Func<TView, TViewProperty>> viewProperty)
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
             where TView : IViewFor<TViewModel>
         {
             return ValidationBinding.ForViewModel<TView, TViewModel, TViewProperty>(view, viewProperty);
@@ -122,7 +122,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, ValidationHelper>> viewModelHelperProperty,
             Expression<Func<TView, TViewProperty>> viewProperty)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             return ValidationBinding.ForValidationHelperProperty(view, viewModelHelperProperty, viewProperty);
         }

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -1,3 +1,9 @@
+// <copyright file="ReactiveValidationObject.cs" company=".NET Foundation">
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// </copyright>
+
 using System;
 using System.Collections;
 using System.ComponentModel;
@@ -12,44 +18,43 @@ using ReactiveUI.Validation.Extensions;
 namespace ReactiveUI.Validation.Helpers
 {
     /// <summary>
-    /// Base class for ReactiveObjects that support INotifyDataErrorInfo validation. 
+    /// Base class for ReactiveObjects that support INotifyDataErrorInfo validation.
     /// </summary>
     /// <typeparam name="TViewModel">The parent view model.</typeparam>
     public abstract class ReactiveValidationObject<TViewModel> : ReactiveObject, IValidatableViewModel, INotifyDataErrorInfo
     {
         private readonly ObservableAsPropertyHelper<bool> _hasErrors;
-    
+
         /// <summary>
-        /// Initializes a new instance of the ReactiveValidationObject.
+        /// Initializes a new instance of the <see cref="ReactiveValidationObject{TViewModel}"/> class.
         /// </summary>
         /// <param name="scheduler">Scheduler for OAPHs and for the the ValidationContext.</param>
-        /// <inheritdoc />
         protected ReactiveValidationObject(IScheduler scheduler = null)
         {
             ValidationContext = new ValidationContext(scheduler);
-        
+
             _hasErrors = this
                 .IsValid()
                 .Select(valid => !valid)
                 .ToProperty(this, x => x.HasErrors, scheduler: scheduler);
-        
+
             ValidationContext
                 .ValidationStatusChange
-                .CombineLatest(Changed, (validation, change) => change.PropertyName)
+                .CombineLatest(Changed, (_, change) => change.PropertyName)
                 .Where(name => name != nameof(HasErrors))
                 .Select(name => new DataErrorsChangedEventArgs(name))
-                .Subscribe(args => ErrorsChanged?.Invoke(this, args)); 
+                .Subscribe(args => ErrorsChanged?.Invoke(this, args));
         }
 
         /// <inheritdoc />
+        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+
+        /// <inheritdoc />
         public bool HasErrors => _hasErrors.Value;
-    
+
         /// <inheritdoc />
         public ValidationContext ValidationContext { get; }
 
-        /// <inheritdoc />
-        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
-    
         /// <summary>
         /// Returns a collection of error messages, required by the INotifyDataErrorInfo interface.
         /// </summary>
@@ -62,15 +67,17 @@ namespace ReactiveUI.Validation.Helpers
                 .GetMember(propertyName)
                 .FirstOrDefault()?
                 .ToString();
-            
-            if (memberInfoName == null) 
+
+            if (memberInfoName == null)
+            {
                 return Enumerable.Empty<string>();
-            
+            }
+
             var relatedPropertyValidations = ValidationContext
                 .Validations
                 .OfType<BasePropertyValidation<TViewModel>>()
                 .Where(validation => validation.ContainsPropertyName(memberInfoName));
-                
+
             return relatedPropertyValidations
                 .Where(validation => !validation.IsValid)
                 .SelectMany(validation => validation.Text)

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using ReactiveUI.Validation.Abstractions;
+using ReactiveUI.Validation.Components;
+using ReactiveUI.Validation.Contexts;
+using ReactiveUI.Validation.Extensions;
+
+namespace ReactiveUI.Validation.Helpers
+{
+    public abstract class ReactiveValidationObject<TViewModel> : ReactiveObject, IValidatableViewModel, INotifyDataErrorInfo
+    {
+        private readonly ObservableAsPropertyHelper<bool> _hasErrors;
+    
+        protected ReactiveValidationObject(IScheduler scheduler = null)
+        {
+            ValidationContext = new ValidationContext(scheduler);
+        
+            _hasErrors = this
+                .IsValid()
+                .Select(valid => !valid)
+                .ToProperty(this, x => x.HasErrors, scheduler: scheduler);
+        
+            ValidationContext
+                .ValidationStatusChange
+                .CombineLatest(Changed, (validation, change) => change.PropertyName)
+                .Where(name => name != nameof(HasErrors))
+                .Select(name => new DataErrorsChangedEventArgs(name))
+                .Subscribe(args => ErrorsChanged?.Invoke(this, args)); 
+        }
+
+        public bool HasErrors => _hasErrors.Value;
+    
+        public ValidationContext ValidationContext { get; }
+
+        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+    
+        public IEnumerable GetErrors(string propertyName)
+        {
+            var memberInfoName = GetType()
+                .GetMember(propertyName)
+                .FirstOrDefault()?
+                .ToString();
+            
+            if (memberInfoName == null) 
+                return Enumerable.Empty<string>();
+            
+            var relatedPropertyValidations = ValidationContext
+                .Validations
+                .OfType<BasePropertyValidation<TViewModel>>()
+                .Where(validation => validation.ContainsPropertyName(memberInfoName));
+                
+            return relatedPropertyValidations
+                .Where(validation => !validation.IsValid)
+                .SelectMany(validation => validation.Text)
+                .ToList();
+        }
+    }
+}

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -11,10 +11,19 @@ using ReactiveUI.Validation.Extensions;
 
 namespace ReactiveUI.Validation.Helpers
 {
+    /// <summary>
+    /// Base class for ReactiveObjects that support INotifyDataErrorInfo validation. 
+    /// </summary>
+    /// <typeparam name="TViewModel">The parent view model.</typeparam>
     public abstract class ReactiveValidationObject<TViewModel> : ReactiveObject, IValidatableViewModel, INotifyDataErrorInfo
     {
         private readonly ObservableAsPropertyHelper<bool> _hasErrors;
     
+        /// <summary>
+        /// Initializes a new instance of the ReactiveValidationObject.
+        /// </summary>
+        /// <param name="scheduler">Scheduler for OAPHs and for the the ValidationContext.</param>
+        /// <inheritdoc />
         protected ReactiveValidationObject(IScheduler scheduler = null)
         {
             ValidationContext = new ValidationContext(scheduler);
@@ -32,13 +41,22 @@ namespace ReactiveUI.Validation.Helpers
                 .Subscribe(args => ErrorsChanged?.Invoke(this, args)); 
         }
 
+        /// <inheritdoc />
         public bool HasErrors => _hasErrors.Value;
     
+        /// <inheritdoc />
         public ValidationContext ValidationContext { get; }
 
+        /// <inheritdoc />
         public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
     
-        public IEnumerable GetErrors(string propertyName)
+        /// <summary>
+        /// Returns a collection of error messages, required by the INotifyDataErrorInfo interface.
+        /// </summary>
+        /// <param name="propertyName">Property to search error notifications for.</param>
+        /// <returns>A list of error messages, usually strings.</returns>
+        /// <inheritdoc />
+        public virtual IEnumerable GetErrors(string propertyName)
         {
             var memberInfoName = GetType()
                 .GetMember(propertyName)

--- a/src/ReactiveUI.Validation/Platforms/Android/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Platforms/Android/ViewForExtensions.cs
@@ -45,7 +45,7 @@ namespace ReactiveUI.Validation.Platforms.Android
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             TextInputLayout viewProperty)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             return ValidationBinding.ForProperty(
                 view,
@@ -73,7 +73,7 @@ namespace ReactiveUI.Validation.Platforms.Android
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             TextInputLayout viewProperty)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             return ValidationBindingEx.ForProperty(
                 view,
@@ -103,7 +103,7 @@ namespace ReactiveUI.Validation.Platforms.Android
             Expression<Func<TViewModel, ValidationHelper>> viewModelHelperProperty,
             TextInputLayout viewProperty)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             return ValidationBinding.ForValidationHelperProperty(
                 view,

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -55,7 +55,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             IValidationTextFormatter<string> formatter = null,
             bool strict = true)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             if (formatter == null)
             {
@@ -102,7 +102,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             IValidationTextFormatter<TOut> formatter = null,
             bool strict = true)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             if (formatter == null)
             {
@@ -145,7 +145,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string> formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             if (formatter == null)
             {
@@ -188,7 +188,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             Action<ValidationState, TOut> action,
             IValidationTextFormatter<TOut> formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             if (formatter == null)
             {
@@ -229,7 +229,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             Action<TOut> action,
             IValidationTextFormatter<TOut> formatter)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             if (formatter == null)
             {
@@ -266,7 +266,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string> formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             if (formatter == null)
             {

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBindingEx.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBindingEx.cs
@@ -52,7 +52,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             IValidationTextFormatter<string> formatter = null,
             bool strict = true)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             if (formatter == null)
             {
@@ -96,7 +96,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             IValidationTextFormatter<TOut> formatter = null,
             bool strict = true)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, ISupportsValidation
+            where TViewModel : ReactiveObject, IValidatableViewModel
         {
             if (formatter == null)
             {
@@ -148,7 +148,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             {
                 return valueChange
                    .Do(
-                       x => setter(target, x.First(msg => !string.IsNullOrEmpty(msg)), viewExpression.GetArgumentsArray()),
+                       x => setter(target, x.FirstOrDefault(msg => !string.IsNullOrEmpty(msg)) ?? string.Empty, viewExpression.GetArgumentsArray()),
                        ex => LogHost.Default.Error(ex, $"{viewExpression} Binding received an Exception!"));
             }
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR introduces a set of two major changes, one of them is breaking:
- The `ISupportsValidation` interface is refactored into `IValidatableViewModel`, to match the new ReactiveUI 10 [activation-related things naming](https://github.com/reactiveui/ReactiveUI/releases/tag/10.0.1), e.g. `IActivatableViewModel`;
- The abstract base class `ReactiveValidationObject<TViewModel>` is added, which encapsulates `INotifyDataErrorInfo` support for platforms such as WPF, Avalonia, Xamarin.Forms. Closes https://github.com/reactiveui/ReactiveUI.Validation/issues/37

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, `INotifyDataErrorInfo` isn't supported and `ISupportsValidation` isn't renamed.

**What is the new behavior?**
<!-- If this is a feature change -->

`INotifyDataErrorInfo` is supported, `ISupportsValidation` is renamed to `IValidatableViewModel`.

<image src="https://user-images.githubusercontent.com/6759207/63812948-ae398b80-c934-11e9-8af2-7123bd250513.png" width="400" />

**What might this PR break?**

Existing code bases which rely on the `ISupportsValidation` interface naming may break, so probably we should document the update instructions. Also, a small bug causing a `Sequence contains no elements` exception was fixed https://github.com/reactiveui/ReactiveUI.Validation/blob/master/src/ReactiveUI.Validation/ValidationBindings/ValidationBindingEx.cs#L151

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] XML Docs have been added / updated (for bug fixes / features)