### PR TITLE
Housekeeping: Update MSBuild.Sdk.Extras

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -1,8 +1,5 @@
 {
-    "sdk": {
-        "version": "3.0.100-preview"
-    },
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "2.0.43"
+        "MSBuild.Sdk.Extras": "2.0.54"
     }
 }


### PR DESCRIPTION
Build fails due to .Net Core SDK which is no longer available on hosted agent. Aligned this file with other JSONs from the Reactive UI family.

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Removes SDK definition
Updates MSBuild.SDK.Extras version



**What is the current behavior?**
The build is failing on the agent.



**What is the new behavior?**
The build should work again.



**What might this PR break?**
The build may still be broken after this.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

