### PR TITLE
Fix ReactiveValidationObject<T> concurrency issues

### DIFF
--- a/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
+++ b/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
@@ -113,14 +113,13 @@ namespace ReactiveUI.Validation.Tests
             Assert.False(viewModel.ValidationContext.IsValid);
             Assert.Single(viewModel.ValidationContext.Validations);
             Assert.Single(viewModel.GetErrors("Name").Cast<string>());
-            Assert.Null(arguments);
 
             viewModel.Name = "JoJo";
 
             Assert.False(viewModel.HasErrors);
             Assert.Empty(viewModel.GetErrors("Name").Cast<string>());
             Assert.NotNull(arguments);
-            Assert.Equal("Name", arguments.PropertyName);
+            Assert.Equal(string.Empty, arguments.PropertyName);
         }
     }
 }

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -38,7 +38,7 @@ namespace ReactiveUI.Validation.Helpers
                 .Select(valid => !valid)
                 .ToProperty(this, x => x.HasErrors, scheduler: scheduler);
 
-            this.IsValid()
+            ValidationContext.ValidationStatusChange
                 .Select(validity => new DataErrorsChangedEventArgs(string.Empty))
                 .Subscribe(args => ErrorsChanged?.Invoke(this, args));
         }

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -38,11 +38,8 @@ namespace ReactiveUI.Validation.Helpers
                 .Select(valid => !valid)
                 .ToProperty(this, x => x.HasErrors, scheduler: scheduler);
 
-            ValidationContext
-                .ValidationStatusChange
-                .CombineLatest(Changed, (_, change) => change.PropertyName)
-                .Where(name => name != nameof(HasErrors))
-                .Select(name => new DataErrorsChangedEventArgs(name))
+            this.IsValid()
+                .Select(validity => new DataErrorsChangedEventArgs(string.Empty))
                 .Subscribe(args => ErrorsChanged?.Invoke(this, args));
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fix concurrency issues related to `INotifyDataErrorInfo.ErrorsChanged` event invocation.

**What is the current behavior?**

Currently, the `INotifyDataErrorInfo.ErrorsChanged` event is raised too often, each time any of the `ValidationContext.ValidationStatusChange` and `ReactiveObject.Changed` observables signal. The `ValidationStatusChange` observable emits new values when validation status changes for any of the properties, and the `ReactiveObject.Changed` event is raised when any property changes. Although this approach allows us to obtain the name of the changed property, this results in unnecessary calls to `ErrorsChanged` and has concurrency issues (e.g. the `INotifyDataErrorInfo.GetErrors` gets called when validation error messages haven't arrived yet)

**What is the new behavior?**
<!-- If this is a feature change -->

Platforms that support `INotifyDataErrorInfo`, including Avalonia, WPF and Xamarin.Forms, will call the `INotifyDataErrorInfo.GetErrors` method for every property when the `INotifyDataErrorInfo.ErrorsChanged` event is raised with `string.Empty` as the event argument. So doing somewhat like:

```cs
ValidationContext.ValidationStatusChange
    .Select(validity => new DataErrorsChangedEventArgs(string.Empty))
    .Subscribe(args => ErrorsChanged?.Invoke(this, args));
```

Fixes the issue described above.

**What might this PR break?**

Nothing except platforms that don't understand `string.Empty` for `INotifyDataErrorInfo.ErrorsChanged`, if such platforms exist. Tested the updated `ReactiveValidationObject<T>` abstract base class on WPF and AvaloniaUI default `TextBox` controls and the new approach also works fine (those red circles appear inside text fields due to `INotifyDataErrorInfo.ErrorsChanged` event being invoked). Previously, there were a few misvalidations

![ezgif-6-ac1b4d5773af](https://user-images.githubusercontent.com/6759207/72221833-4dbb8b80-356f-11ea-8f37-5bad80a4eb13.gif)