### PR TITLE
ModelObservableValidation + INotifyDataErrorInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ public class SampleViewModel : ReactiveObject, IValidatableViewModel
 }
 ```
 
+For more complex validations there is also the possibility to supply an `Observable<bool>` indicating whether the rule is valid or not. Thus you can combine multiple properties or incorporate other complex logic.
+
+```csharp
+            this.ValidationRule(
+                m => m.WhenAnyValue(m1 => m1.TextInput1, m1 => m1.TextInput2).Select(both => both.Item1 == both.Item2),
+                (vm, isValid) => isValid ? string.Empty : "Both inputs should be the same");
+
+```
+
 2. Add validation presentation to the View.
 
 ```csharp
@@ -136,6 +145,18 @@ public class SampleViewModel : ReactiveValidationObject<SampleViewModel>
 ```
 
 > **Note** The `Reactive` attribute is from the [ReactiveUI.Fody](https://reactiveui.net/docs/handbook/view-models/boilerplate-code) NuGet package.
+
+When using the `ValidationRule` overload that uses `Observable<bool>` for more complex scenarios please keep in mind to supply the property which the validation rule is targeting as the first argument. Otherwise it is not possible for `INotifyDataErrorInfo` to conclude which property the error message is for.
+
+```csharp
+            this.ValidationRule(
+                m => m.TextInput2,
+                m => m.WhenAnyValue(m1 => m1.TextInput1, m1 => m1.TextInput2).Select(both => both.Item1 == both.Item2),
+                (vm, isValid) => isValid ? string.Empty : "Both inputs should be the same");
+
+```
+
+
 
 ## Capabilities
 

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -32,6 +32,13 @@ namespace ReactiveUI.Validation.Comparators
 }
 namespace ReactiveUI.Validation.Components.Abstractions
 {
+    public interface IPropertyValidationComponent<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
+    public interface IValidatesProperties<TViewModel>
+    {
+        int PropertyCount { get; }
+        bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = False);
+        bool ContainsPropertyName(string propertyName, bool exclusively = False);
+    }
     public interface IValidationComponent
     {
         bool IsValid { get; }
@@ -41,7 +48,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
 }
 namespace ReactiveUI.Validation.Components
 {
-    public abstract class BasePropertyValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class BasePropertyValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
         protected BasePropertyValidation() { }
         public bool IsValid { get; }
@@ -63,14 +70,29 @@ namespace ReactiveUI.Validation.Components
         protected override void Dispose(bool disposing) { }
         protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
     }
-    public class ModelObservableValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
-        public ModelObservableValidation(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
+        public ModelObservableValidationBase(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
+        protected ModelObservableValidationBase(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
         public bool IsValid { get; }
+        public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = False) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = False) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+    }
+    public class ModelObservableValidation<TViewModel> : ReactiveUI.Validation.Components.ModelObservableValidationBase<TViewModel>
+    {
+        public ModelObservableValidation(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
+        public ModelObservableValidation(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
+    }
+    public class ModelObservableValidation<TViewModel, TViewModelProp> : ReactiveUI.Validation.Components.ModelObservableValidationBase<TViewModel>
+    {
+        public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
+        public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
     }
 }
 namespace ReactiveUI.Validation.Contexts

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp2.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp2.1.approved.txt
@@ -32,6 +32,13 @@ namespace ReactiveUI.Validation.Comparators
 }
 namespace ReactiveUI.Validation.Components.Abstractions
 {
+    public interface IPropertyValidationComponent<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
+    public interface IValidatesProperties<TViewModel>
+    {
+        int PropertyCount { get; }
+        bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = False);
+        bool ContainsPropertyName(string propertyName, bool exclusively = False);
+    }
     public interface IValidationComponent
     {
         bool IsValid { get; }
@@ -41,7 +48,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
 }
 namespace ReactiveUI.Validation.Components
 {
-    public abstract class BasePropertyValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class BasePropertyValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
         protected BasePropertyValidation() { }
         public bool IsValid { get; }
@@ -63,14 +70,29 @@ namespace ReactiveUI.Validation.Components
         protected override void Dispose(bool disposing) { }
         protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
     }
-    public class ModelObservableValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
-        public ModelObservableValidation(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
+        public ModelObservableValidationBase(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
+        protected ModelObservableValidationBase(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
         public bool IsValid { get; }
+        public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = False) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = False) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+    }
+    public class ModelObservableValidation<TViewModel> : ReactiveUI.Validation.Components.ModelObservableValidationBase<TViewModel>
+    {
+        public ModelObservableValidation(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
+        public ModelObservableValidation(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
+    }
+    public class ModelObservableValidation<TViewModel, TViewModelProp> : ReactiveUI.Validation.Components.ModelObservableValidationBase<TViewModel>
+    {
+        public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
+        public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
     }
 }
 namespace ReactiveUI.Validation.Contexts

--- a/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
@@ -1,0 +1,16 @@
+// <copyright file="ReactiveUI.Validation/src/ReactiveUI.Validation/Components/Abstractions/IValidationComponent.cs" company=".NET Foundation">
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// </copyright>
+
+namespace ReactiveUI.Validation.Components.Abstractions
+{
+    /// <summary>
+    /// a component specifically validating one or more properties.
+    /// </summary>
+    /// <typeparam name="TViewModel">The validation target.</typeparam>
+    public interface IPropertyValidationComponent<TViewModel> : IValidationComponent, IValidatesProperties<TViewModel>
+    {
+    }
+}

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="ReactiveUI.Validation/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs" company=".NET Foundation">
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// </copyright>
+
+using System;
+using System.Linq.Expressions;
+
+namespace ReactiveUI.Validation.Components.Abstractions
+{
+    /// <summary>
+    /// Interface marking a validation component that validates specific properties.
+    /// </summary>
+    /// <typeparam name="TViewModel">The validation target.</typeparam>
+    public interface IValidatesProperties<TViewModel>
+    {
+        /// <summary>
+        /// Gets the total number of properties referenced.
+        /// </summary>
+        int PropertyCount { get; }
+
+        /// <summary>
+        /// Determine if a property name is actually contained within this.
+        /// </summary>
+        /// <typeparam name="TProp">Any type.</typeparam>
+        /// <param name="propertyExpression">ViewModel property.</param>
+        /// <param name="exclusively">Indicates if the property to find is unique.</param>
+        /// <returns>Returns true if it contains the property, otherwise false.</returns>
+        bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
+
+        /// <summary>
+        /// Determine if a property name is actually contained within this.
+        /// </summary>
+        /// <param name="propertyName">ViewModel property name.</param>
+        /// <param name="exclusively">Indicates if the property to find is unique.</param>
+        /// <returns>Returns true if it contains the property, otherwise false.</returns>
+        bool ContainsPropertyName(string propertyName, bool exclusively = false);
+    }
+}

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -20,11 +20,11 @@ namespace ReactiveUI.Validation.Components
 {
     /// <inheritdoc cref="ReactiveObject" />
     /// <inheritdoc cref="IDisposable" />
-    /// <inheritdoc cref="IValidationComponent" />
+    /// <inheritdoc cref="IPropertyValidationComponent{TViewModel}" />
     /// <summary>
     /// Base class for items which are used to build a <see cref="ReactiveUI.Validation.Contexts.ValidationContext" />.
     /// </summary>
-    public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisposable, IValidationComponent, IValidatesProperties<TViewModel>
+    public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent<TViewModel>
     {
         /// <summary>
         /// The current valid state.

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI.Validation.Components
     /// <summary>
     /// Base class for items which are used to build a <see cref="ReactiveUI.Validation.Contexts.ValidationContext" />.
     /// </summary>
-    public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisposable, IValidationComponent
+    public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisposable, IValidationComponent, IValidatesProperties<TViewModel>
     {
         /// <summary>
         /// The current valid state.
@@ -32,7 +32,7 @@ namespace ReactiveUI.Validation.Components
         private readonly ReplaySubject<bool> _isValidSubject = new ReplaySubject<bool>(1);
 
         /// <summary>
-        /// The list of property names this validator.
+        /// The list of property names this validator is referencing.
         /// </summary>
         private readonly HashSet<string> _propertyNames = new HashSet<string>();
 
@@ -64,9 +64,7 @@ namespace ReactiveUI.Validation.Components
             _disposables.Add(_isValidSubject.Subscribe(v => _isValid = v));
         }
 
-        /// <summary>
-        /// Gets get the total number of properties referenced.
-        /// </summary>
+        /// <inheritdoc/>
         public int PropertyCount => _propertyNames.Count;
 
         /// <inheritdoc />
@@ -111,25 +109,14 @@ namespace ReactiveUI.Validation.Components
             GC.SuppressFinalize(this);
         }
 
-        /// <summary>
-        /// Determine if a property name is actually contained within this.
-        /// </summary>
-        /// <typeparam name="TProp">Any type.</typeparam>
-        /// <param name="property">ViewModel property.</param>
-        /// <param name="exclusively">Indicates if the property to find is unique.</param>
-        /// <returns>Returns true if it contains the property, otherwise false.</returns>
+        /// <inheritdoc/>
         public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
         {
             var propertyName = property.Body.GetMemberInfo().ToString();
             return ContainsPropertyName(propertyName, exclusively);
         }
 
-        /// <summary>
-        /// Determine if a property name is actually contained within this.
-        /// </summary>
-        /// <param name="propertyName">ViewModel property name.</param>
-        /// <param name="exclusively">Indicates if the property to find is unique.</param>
-        /// <returns>Returns true if it contains the property, otherwise false.</returns>
+        /// <inheritdoc/>
         public bool ContainsPropertyName(string propertyName, bool exclusively = false)
         {
             return exclusively

--- a/src/ReactiveUI.Validation/Components/ModelObservableValidationBase.cs
+++ b/src/ReactiveUI.Validation/Components/ModelObservableValidationBase.cs
@@ -17,7 +17,7 @@ using ReactiveUI.Validation.States;
 namespace ReactiveUI.Validation.Components
 {
     /// <inheritdoc cref="ReactiveObject" />
-    /// <inheritdoc cref="IValidationComponent" />
+    /// <inheritdoc cref="IPropertyValidationComponent{TViewModel}" />
     /// <inheritdoc cref="IDisposable" />
     /// <summary>
     /// More generic observable for determination of validity.
@@ -27,7 +27,7 @@ namespace ReactiveUI.Validation.Components
     /// passed through?
     /// Also, what about access to the view model to output the error message?.
     /// </remarks>
-    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveObject, IValidationComponent, IDisposable, IValidatesProperties<TViewModel>
+    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent<TViewModel>
     {
         private readonly ReplaySubject<ValidationState> _lastValidationStateSubject =
             new ReplaySubject<ValidationState>(1);

--- a/src/ReactiveUI.Validation/Components/ModelObservableValidationBase.cs
+++ b/src/ReactiveUI.Validation/Components/ModelObservableValidationBase.cs
@@ -1,0 +1,180 @@
+// <copyright file="ReactiveUI.Validation/src/ReactiveUI.Validation/Components/ModelObservableValidationBase.cs" company=".NET Foundation">
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using ReactiveUI.Validation.Collections;
+using ReactiveUI.Validation.Components.Abstractions;
+using ReactiveUI.Validation.States;
+
+namespace ReactiveUI.Validation.Components
+{
+    /// <inheritdoc cref="ReactiveObject" />
+    /// <inheritdoc cref="IValidationComponent" />
+    /// <inheritdoc cref="IDisposable" />
+    /// <summary>
+    /// More generic observable for determination of validity.
+    /// </summary>
+    /// <remarks>
+    /// We probably need a more 'complex' one, where the params of the validation block are
+    /// passed through?
+    /// Also, what about access to the view model to output the error message?.
+    /// </remarks>
+    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveObject, IValidationComponent, IDisposable, IValidatesProperties<TViewModel>
+    {
+        private readonly ReplaySubject<ValidationState> _lastValidationStateSubject =
+            new ReplaySubject<ValidationState>(1);
+
+        /// <summary>
+        /// The list of property names this validator is referencing.
+        /// </summary>
+        private readonly HashSet<string> _propertyNames = new HashSet<string>();
+
+        // the underlying connected observable for the validation change which is published
+        private readonly IConnectableObservable<ValidationState> _validityConnectedObservable;
+
+        private CompositeDisposable _disposables = new CompositeDisposable();
+
+        private bool _isActive;
+
+        private bool _isValid;
+
+        private ValidationText _text;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelObservableValidationBase{TViewModel}"/> class.
+        /// </summary>
+        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="validityObservable">Func to define if the viewModel is valid or not.</param>
+        /// <param name="messageFunc">Func to define the validation error message based on the viewModel and validityObservable values.</param>
+        public ModelObservableValidationBase(
+            TViewModel viewModel,
+            Func<TViewModel, IObservable<bool>> validityObservable,
+            Func<TViewModel, bool, string> messageFunc)
+            : this(viewModel, validityObservable, (vm, state) => new ValidationText(messageFunc(vm, state)))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelObservableValidationBase{TViewModel}"/> class.
+        /// </summary>
+        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="validityObservable">Func to define if the viewModel is valid or not.</param>
+        /// <param name="messageFunc">Func to define the validation error message based on the viewModel and validityObservable values.</param>
+        protected ModelObservableValidationBase(
+            TViewModel viewModel,
+            Func<TViewModel, IObservable<bool>> validityObservable,
+            Func<TViewModel, bool, ValidationText> messageFunc)
+        {
+            _disposables.Add(_lastValidationStateSubject.Do(s =>
+            {
+                _isValid = s.IsValid;
+                _text = s.Text;
+            }).Subscribe());
+
+            _validityConnectedObservable = Observable.Defer(() => validityObservable(viewModel))
+                .Select(v => new ValidationState(v, messageFunc(viewModel, v), this))
+                .Multicast(_lastValidationStateSubject);
+        }
+
+        /// <inheritdoc/>
+        public int PropertyCount => _propertyNames.Count;
+
+        /// <inheritdoc/>
+        public ValidationText Text
+        {
+            get
+            {
+                Activate();
+                return _text;
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsValid
+        {
+            get
+            {
+                Activate();
+                return _isValid;
+            }
+        }
+
+        /// <inheritdoc/>
+        public IObservable<ValidationState> ValidationStatusChange
+        {
+            get
+            {
+                Activate();
+                return _validityConnectedObservable;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Dispose of unmanaged resources.
+            Dispose(true);
+
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc/>
+        public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
+        {
+            var propertyName = property.Body.GetMemberInfo().ToString();
+            return ContainsPropertyName(propertyName, exclusively);
+        }
+
+        /// <inheritdoc/>
+        public bool ContainsPropertyName(string propertyName, bool exclusively = false)
+        {
+            return exclusively
+                ? _propertyNames.Contains(propertyName) && _propertyNames.Count == 1
+                : _propertyNames.Contains(propertyName);
+        }
+
+        /// <summary>
+        /// Disposes of the managed resources.
+        /// </summary>
+        /// <param name="disposing">If its getting called by the <see cref="BasePropertyValidation{TViewModel}.Dispose()"/> method.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _disposables?.Dispose();
+                _disposables = null;
+            }
+        }
+
+        /// <summary>
+        /// Adds a property to the list of this which this validation is associated with.
+        /// </summary>
+        /// <typeparam name="TProp">Any type.</typeparam>
+        /// <param name="property">ViewModel property.</param>
+        protected void AddProperty<TProp>(Expression<Func<TViewModel, TProp>> property)
+        {
+            var propertyName = property.Body.GetMemberInfo().ToString();
+            _propertyNames.Add(propertyName);
+        }
+
+        private void Activate()
+        {
+            if (_isActive)
+            {
+                return;
+            }
+
+            _isActive = true;
+            _disposables.Add(_validityConnectedObservable.Connect());
+        }
+    }
+}

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using ReactiveUI.Validation.Abstractions;
-using ReactiveUI.Validation.Components;
+using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.Contexts;
 using ReactiveUI.Validation.Extensions;
 
@@ -72,7 +72,7 @@ namespace ReactiveUI.Validation.Helpers
 
             var relatedPropertyValidations = ValidationContext
                 .Validations
-                .OfType<BasePropertyValidation<TViewModel>>()
+                .OfType<IPropertyValidationComponent<TViewModel>>()
                 .Where(validation => validation.ContainsPropertyName(memberInfoName));
 
             return relatedPropertyValidations

--- a/stylecop.json
+++ b/stylecop.json
@@ -18,7 +18,7 @@
         "readonly"
       ],
       "systemUsingDirectivesFirst": true,
-      "usingDirectivesPlacement": "outsideNameSpace"
+      "usingDirectivesPlacement": "outsideNamespace"
     },
     "maintainabilityRules": {
       "topLevelTypes": ["class"]


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**

- new overload for this.ValidationRule extension method that takes a Func<ViewModel, IObservable<bool>> as well as a lambda that states which property the rule refers to.
- new common base interface `IPropertyValidationComponent<TViewModel>` for `BasePropertyValidation` and `ModelObservableValidationBase` to access `ContainsPropertyName`/`IsValid`/`Text` uniformly (in `INotifyDataErrorInfo.GetErrors` implementation)
- new abstract base class ModelObservableValidationBase (to later on generate more overloads analog to BasePropertyValidation by .tt file)

**What is the current behavior?**
Until now INotifyDataErrorInfo did not work in conjunction with using the Func<ViewModel, IObservable<bool>> overload of the ValidationRule extension method. ReactiveValidationObject.GetErrors considered only simple ValidationRules.

**What is the new behavior?**
Now we have the possibility to use the overload of ValidationRule that takes a Func<ViewModel, IObservable<bool>> in combination with INotifyDataErrorInfo. The user can now inform the framework through a given lambda which property exactly the ValidationRule is validating. Thus INotifyDataErrorInfo has the possibility to work as advertised, namely finding the validation message for a certain (changed) bound property.

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

