### PR TITLE
extension and testcase for new ModelObservableValidation

### DIFF
--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -134,6 +134,8 @@ namespace ReactiveUI.Validation.Extensions
             where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
             where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
     public class static ValidationContextExtensions
     {

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp2.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp2.1.approved.txt
@@ -134,6 +134,8 @@ namespace ReactiveUI.Validation.Extensions
             where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
             where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
+            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
     public class static ValidationContextExtensions
     {

--- a/src/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
@@ -9,6 +9,7 @@ namespace ReactiveUI.Validation.Tests.Models
     public class IndeiTestViewModel : ReactiveValidationObject<IndeiTestViewModel>
     {
         private string _name;
+        private string _otherName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IndeiTestViewModel"/> class.
@@ -25,6 +26,15 @@ namespace ReactiveUI.Validation.Tests.Models
         {
             get => _name;
             set => this.RaiseAndSetIfChanged(ref _name, value);
+        }
+
+        /// <summary>
+        /// Gets or sets get the Name.
+        /// </summary>
+        public string OtherName
+        {
+            get => _otherName;
+            set => this.RaiseAndSetIfChanged(ref _otherName, value);
         }
     }
 }

--- a/src/ReactiveUI.Validation/Extensions/SupportsValidationExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/SupportsValidationExtensions.cs
@@ -104,6 +104,34 @@ namespace ReactiveUI.Validation.Extensions
         }
 
         /// <summary>
+        /// Setup a validation rule with a general observable indicating validity.
+        /// </summary>
+        /// <typeparam name="TViewModel">ViewModel type.</typeparam>
+        /// <typeparam name="TViewModelProp">ViewModel property type.</typeparam>
+        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModelProperty">ViewModel property referenced in viewModelObservableProperty.</param>
+        /// <param name="viewModelObservableProperty">Func to define if the viewModel is valid or not.</param>
+        /// <param name="messageFunc">Func to define the validation error message based on the viewModel and viewModelObservableProperty values.</param>
+        /// <returns>Returns a <see cref="ValidationHelper"/> object.</returns>
+        /// <remarks>
+        /// It should be noted that the observable should provide an initial value, otherwise that can result
+        /// in an inconsistent performance.
+        /// </remarks>
+        public static ValidationHelper ValidationRule<TViewModel, TViewModelProp>(
+            this TViewModel viewModel,
+            Expression<Func<TViewModel, TViewModelProp>> viewModelProperty,
+            Func<TViewModel, IObservable<bool>> viewModelObservableProperty,
+            Func<TViewModel, bool, string> messageFunc)
+            where TViewModel : ReactiveObject, IValidatableViewModel
+        {
+            var validation = new ModelObservableValidation<TViewModel, TViewModelProp>(viewModel, viewModelProperty, viewModelObservableProperty, messageFunc);
+
+            viewModel.ValidationContext.Add(validation);
+
+            return new ValidationHelper(validation);
+        }
+
+        /// <summary>
         /// Gets an observable for the validity of the ViewModel.
         /// </summary>
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
- adds a testcase checking for the functionality of INDEI.GetErrors in context with ModelObservableValidation + property lambda
- adds the corresponding extension method (ValidationRule)

**What is the current behavior?**
- no test
- no extension method

**What is the new behavior?**
- test
- extension method

**What might this PR break?**
nothing, hopefully


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

