### PR TITLE
Use TaskpoolScheduler for WPF/WF ValidationContext

### DIFF
--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -1,11 +1,14 @@
 <Project>
-  <PropertyGroup>  
+  <PropertyGroup>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AndroidUseIntermediateDesignerFile>False</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <DefineConstants>$(DefineConstants);NET_45;XAML</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET_461;XAML</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">
     <DefineConstants>$(DefineConstants);NETFX_CORE;XAML;WINDOWS_UWP</DefineConstants>

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -51,7 +51,11 @@ namespace ReactiveUI.Validation.Contexts
         /// <param name="scheduler">Optional scheduler to use for the properties. Uses the main thread scheduler by default.</param>
         public ValidationContext(IScheduler scheduler = null)
         {
+#if NET_461 || NETSTANDARD
+            scheduler = scheduler ?? RxApp.TaskpoolScheduler;
+#else
             scheduler = scheduler ?? RxApp.MainThreadScheduler;
+#endif
 
             var validationChangedObservable = _validationSource.Connect();
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
ValidationContext uses RxApp.TaskpoolScheduler instead of RxApp.MainThreadScheduler for WPF and WinForms (NET_461 and NETCOREAPP).
Fixes #34
Fixes #63

**Current workarounds:**
1. public MainViewModel() : base(RxApp.TaskpoolScheduler)
2. public class MainWindowModel : ReactiveObject, IValidatableViewModel
    public ValidationContext ValidationContext { get; } = new
     ValidationContext(RxApp.TaskpoolScheduler);

**What is the current behavior?**
Quote #34
> When having multiple validation rules, I get an IndexOutOfRangeException at Runtime. Both validation rules work when they are enabled individually.

> As I see it, the ValidationContext.Add() method adds validations to the _validationSource but not to the _validations readonly observable collection.

**What is the new behavior?**
No Exception, works as expected.

**What might this PR break?**
Other project types might not work anymore or could be fixed with this approach.

**Other information**:
I created a nuget package for myself with this fix to be able to work with ReactiveUI.Validation in WPF and WinForms. If there is a better way or problems with this fix please let me know. I just wanted to share this fix because there was no fix in a long time and it works for me without any problems.