### PR TITLE
Added support for GetErrors parameter being null

### DIFF
--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
+using System.Collections.Generic;
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.Contexts;

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -24,7 +24,8 @@ namespace ReactiveUI.Validation.Helpers
     public abstract class ReactiveValidationObject<TViewModel> : ReactiveObject, IValidatableViewModel, INotifyDataErrorInfo
     {
         private readonly ObservableAsPropertyHelper<bool> _hasErrors;
-
+        private readonly Dictionary<string, string> propertyMemberNameDictionary = new Dictionary<string, string>();
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactiveValidationObject{TViewModel}"/> class.
         /// </summary>
@@ -60,7 +61,6 @@ namespace ReactiveUI.Validation.Helpers
         /// <inheritdoc />
         public virtual IEnumerable GetErrors(string propertyName)
         {
-            //https://stackoverflow.com/questions/34993261/when-is-inotifydataerrorinfo-geterrors-called-with-null-vs-string-empty
             return string.IsNullOrEmpty(propertyName) ?
                 SelectValidations()
                     .SelectMany(validation => validation.Text)

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -6,11 +6,11 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
-using System.Collections.Generic;
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.Contexts;
@@ -25,8 +25,8 @@ namespace ReactiveUI.Validation.Helpers
     public abstract class ReactiveValidationObject<TViewModel> : ReactiveObject, IValidatableViewModel, INotifyDataErrorInfo
     {
         private readonly ObservableAsPropertyHelper<bool> _hasErrors;
-        private readonly Dictionary<string, string> propertyMemberNameDictionary = new Dictionary<string, string>();
-        
+        private readonly Dictionary<string, string> _propertyMemberNameDictionary = new Dictionary<string, string>();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ReactiveValidationObject{TViewModel}"/> class.
         /// </summary>
@@ -81,14 +81,14 @@ namespace ReactiveUI.Validation.Helpers
                     .Where(validation => !validation.IsValid);
         }
 
-        public string GetMemberInfoName(string propertyName)
+        private string GetMemberInfoName(string propertyName)
         {
-            if (propertyMemberNameDictionary.ContainsKey(propertyName) == false)
+            if (_propertyMemberNameDictionary.ContainsKey(propertyName) == false)
             {
-                propertyMemberNameDictionary.Add(propertyName, GetMemberInfoName());
+                _propertyMemberNameDictionary.Add(propertyName, GetMemberInfoName());
             }
 
-            return propertyMemberNameDictionary[propertyName];
+            return _propertyMemberNameDictionary[propertyName];
 
             string GetMemberInfoName() => GetType()
                 .GetMember(propertyName)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
 Bug fix



**What is the current behavior?**
<!-- You can also link to an open issue here. -->



**What is the new behavior?**
<!-- If this is a feature change -->



**What might this PR break?**
Don't know


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
INotifyDataError can pass null or an empty string to the GetErrors method. This will cause an exeception within the code atm since its calls GetType().GetMember(propertyName) whether propertName is null or not. The code fixes this by checking for null and then notifies for 'entity-level errors.' if so (in line with the documentation).

It also caches the member-name/property-name mappings in a dictionary for faster future retrieval.
