### PR TITLE
Try Resolve a Default Formatter from Splat.Locator

### DIFF
--- a/samples/LoginApp.Avalonia/Views/SignUpView.xaml.cs
+++ b/samples/LoginApp.Avalonia/Views/SignUpView.xaml.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Reactive.Disposables;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
@@ -10,6 +11,7 @@ using Avalonia.ReactiveUI;
 using LoginApp.ViewModels;
 using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
+using ReactiveUI.Validation.Formatters;
 
 namespace LoginApp.Avalonia.Views
 {
@@ -38,7 +40,7 @@ namespace LoginApp.Avalonia.Views
                     .DisposeWith(disposables);
                 this.BindValidation(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordValidation.Text)
                     .DisposeWith(disposables);
-                this.BindValidation(ViewModel, x => x.CompoundValidation.Text)
+                this.BindValidation(ViewModel, x => x.CompoundValidation.Text, new SingleLineFormatter(Environment.NewLine))
                     .DisposeWith(disposables);
             });
         }

--- a/samples/LoginApp.WinForms/Views/SignUpView.cs
+++ b/samples/LoginApp.WinForms/Views/SignUpView.cs
@@ -3,12 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Reactive.Disposables;
 using System.Windows.Forms;
 using LoginApp.ViewModels;
 using LoginApp.WinForms.Services;
 using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
+using ReactiveUI.Validation.Formatters;
 
 namespace LoginApp.WinForms.Views
 {
@@ -42,7 +44,7 @@ namespace LoginApp.WinForms.Views
 
                 this.BindCommand(ViewModel, x => x.SignUp, x => x.SignUpButton)
                     .DisposeWith(disposables);
-                this.BindValidation(ViewModel, x => x.ErrorLabel.Text)
+                this.BindValidation(ViewModel, x => x.ErrorLabel.Text, new SingleLineFormatter(Environment.NewLine))
                     .DisposeWith(disposables);
             });
         }

--- a/samples/LoginApp.Wpf/Views/SignUpView.xaml.cs
+++ b/samples/LoginApp.Wpf/Views/SignUpView.xaml.cs
@@ -3,10 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Reactive.Disposables;
 using LoginApp.ViewModels;
 using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
+using ReactiveUI.Validation.Formatters;
 
 namespace LoginApp.Wpf.Views
 {
@@ -33,7 +35,7 @@ namespace LoginApp.Wpf.Views
                     .DisposeWith(disposables);
                 this.BindValidation(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordValidation.Text)
                     .DisposeWith(disposables);
-                this.BindValidation(ViewModel, x => x.CompoundValidation.Text)
+                this.BindValidation(ViewModel, x => x.CompoundValidation.Text, new SingleLineFormatter(Environment.NewLine))
                     .DisposeWith(disposables);
 
                 this.WhenAnyValue(x => x.UserNameValidation.Text, text => !string.IsNullOrWhiteSpace(text))

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -151,7 +151,7 @@ namespace ReactiveUI.Validation.Extensions
             where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Obsolete("This method is no longer required, BindValidation now supports multiple validatio" +
             "ns.")]
-        public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
+        public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -151,7 +151,7 @@ namespace ReactiveUI.Validation.Extensions
             where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Obsolete("This method is no longer required, BindValidation now supports multiple validatio" +
             "ns.")]
-        public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty)
+        public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }

--- a/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
@@ -396,6 +396,33 @@ namespace ReactiveUI.Validation.Tests
             Assert.Equal(nameErrorMessage, view.NameErrorLabel);
         }
 
+        /// <summary>
+        /// Verifies that we support binding composite ViewModel validations to actions. This feature
+        /// is required for platform-specific extension methods implementation, e.g. the
+        /// <see cref="ViewForExtensions" /> for the Android Platform.
+        /// </summary>
+        [Fact]
+        public void ShouldSupportViewModelActionBindingRequiredForPlatformSpecificImplementations()
+        {
+            const string nameErrorMessage = "Name should not be empty.";
+            var view = new TestView(new TestViewModel { Name = string.Empty });
+
+            view.ViewModel.ValidationRule(
+                vm => vm.Name,
+                s => !string.IsNullOrEmpty(s),
+                nameErrorMessage);
+
+            ValidationBinding.ForViewModel<TestView, TestViewModel, string>(
+                view,
+                errorText => view.NameErrorLabel = errorText,
+                SingleLineFormatter.Default);
+
+            Assert.False(view.ViewModel.ValidationContext.IsValid);
+            Assert.Equal(1, view.ViewModel.ValidationContext.Validations.Count);
+            Assert.NotEmpty(view.NameErrorLabel);
+            Assert.Equal(nameErrorMessage, view.NameErrorLabel);
+        }
+
         private class ConstFormatter : IValidationTextFormatter<string>
         {
             private readonly string _text;

--- a/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
@@ -34,6 +34,11 @@ namespace ReactiveUI.Validation.Extensions
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [Obsolete("This method is no longer required, BindValidation now supports multiple validations.")]
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution")]
@@ -41,7 +46,8 @@ namespace ReactiveUI.Validation.Extensions
             this TView view,
             TViewModel viewModel,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
-            Expression<Func<TView, TViewProperty>> viewProperty)
+            Expression<Func<TView, TViewProperty>> viewProperty,
+            IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
             where TViewModel : ReactiveObject, IValidatableViewModel
         {
@@ -74,7 +80,11 @@ namespace ReactiveUI.Validation.Extensions
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter. Defaults to <see cref="SingleLineFormatter"/>.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution")]
         public static IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(
@@ -113,7 +123,11 @@ namespace ReactiveUI.Validation.Extensions
         /// <param name="view">IViewFor instance.</param>
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter. Defaults to <see cref="SingleLineFormatter"/>.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution")]
         public static IDisposable BindValidation<TView, TViewModel, TViewProperty>(
@@ -147,7 +161,11 @@ namespace ReactiveUI.Validation.Extensions
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelHelperProperty">ViewModel's ValidationHelper property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter. Defaults to <see cref="SingleLineFormatter"/>.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution")]
         public static IDisposable BindValidation<TView, TViewModel, TViewProperty>(

--- a/src/ReactiveUI.Validation/Platforms/Android/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Platforms/Android/ViewForExtensions.cs
@@ -33,7 +33,11 @@ namespace ReactiveUI.Validation.Platforms.Android
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidation<TView, TViewModel, TViewModelProperty>(
@@ -66,7 +70,11 @@ namespace ReactiveUI.Validation.Platforms.Android
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [Obsolete("This method is no longer required, BindValidation now supports multiple validations.")]
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
@@ -98,7 +106,11 @@ namespace ReactiveUI.Validation.Platforms.Android
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelHelperProperty">ViewModel's ValidationHelper property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidation<TView, TViewModel>(

--- a/src/ReactiveUI.Validation/Platforms/Android/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Platforms/Android/ViewForExtensions.cs
@@ -10,8 +10,10 @@ using System.Linq.Expressions;
 using Android.Support.Design.Widget;
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Formatters;
+using ReactiveUI.Validation.Formatters.Abstractions;
 using ReactiveUI.Validation.Helpers;
 using ReactiveUI.Validation.ValidationBindings;
+using Splat;
 
 namespace ReactiveUI.Validation.Platforms.Android
 {
@@ -31,21 +33,26 @@ namespace ReactiveUI.Validation.Platforms.Android
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
+        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidation<TView, TViewModel, TViewModelProperty>(
             this TView view,
             TViewModel viewModel,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
-            TextInputLayout viewProperty)
+            TextInputLayout viewProperty,
+            IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
             where TViewModel : ReactiveObject, IValidatableViewModel
         {
+            formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+                          SingleLineFormatter.Default;
+
             return ValidationBinding.ForProperty(
                 view,
                 viewModelProperty,
                 (_, errors) => viewProperty.Error = errors.FirstOrDefault(msg => !string.IsNullOrEmpty(msg)),
-                SingleLineFormatter.Default);
+                formatter);
         }
 
         /// <summary>
@@ -59,6 +66,7 @@ namespace ReactiveUI.Validation.Platforms.Android
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
+        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [Obsolete("This method is no longer required, BindValidation now supports multiple validations.")]
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
@@ -66,15 +74,19 @@ namespace ReactiveUI.Validation.Platforms.Android
             this TView view,
             TViewModel viewModel,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
-            TextInputLayout viewProperty)
+            TextInputLayout viewProperty,
+            IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
             where TViewModel : ReactiveObject, IValidatableViewModel
         {
+            formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+                          SingleLineFormatter.Default;
+
             return ValidationBinding.ForProperty(
                 view,
                 viewModelProperty,
                 (_, errors) => viewProperty.Error = errors.FirstOrDefault(msg => !string.IsNullOrEmpty(msg)),
-                SingleLineFormatter.Default);
+                formatter);
         }
 
         /// <summary>
@@ -86,21 +98,26 @@ namespace ReactiveUI.Validation.Platforms.Android
         /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelHelperProperty">ViewModel's ValidationHelper property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
+        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
         /// <returns>Returns a <see cref="IDisposable"/> object.</returns>
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidation<TView, TViewModel>(
             this TView view,
             TViewModel viewModel,
             Expression<Func<TViewModel?, ValidationHelper>> viewModelHelperProperty,
-            TextInputLayout viewProperty)
+            TextInputLayout viewProperty,
+            IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
             where TViewModel : ReactiveObject, IValidatableViewModel
         {
+            formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+                          SingleLineFormatter.Default;
+
             return ValidationBinding.ForValidationHelperProperty(
                 view,
                 viewModelHelperProperty,
                 (_, errorText) => viewProperty.Error = errorText,
-                SingleLineFormatter.Default);
+                formatter);
         }
     }
 }

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -97,7 +97,9 @@ namespace ReactiveUI.Validation.ValidationBindings
         }
 
         /// <summary>
-        /// Creates a binding from a specified ViewModel property to a provided action.
+        /// Creates a binding from a specified ViewModel property to a provided action. Such action binding allows
+        /// to easily create new and more specialized platform-specific BindValidation extension methods like those
+        /// we have in <see cref="ViewForExtensions" /> targeting the Android platform.
         /// </summary>
         /// <typeparam name="TView">ViewFor of ViewModel type.</typeparam>
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
@@ -219,7 +221,9 @@ namespace ReactiveUI.Validation.ValidationBindings
         }
 
         /// <summary>
-        /// Creates a binding from a <see cref="ValidationHelper" /> to a specified action.
+        /// Creates a binding from a <see cref="ValidationHelper" /> to a specified action. Such action binding allows
+        /// to easily create new and more specialized platform-specific BindValidation extension methods like those
+        /// we have in <see cref="ViewForExtensions" /> targeting the Android platform.
         /// </summary>
         /// <typeparam name="TView">ViewFor of ViewModel type.</typeparam>
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
@@ -275,7 +279,9 @@ namespace ReactiveUI.Validation.ValidationBindings
         }
 
         /// <summary>
-        /// Creates a binding between a ViewModel and a specified action.
+        /// Creates a binding between a ViewModel and a specified action. Such action binding allows to easily create
+        /// new and more specialized platform-specific BindValidation extension methods like those we have in
+        /// <see cref="ViewForExtensions" /> targeting the Android platform.
         /// </summary>
         /// <typeparam name="TView">ViewFor of ViewModel type.</typeparam>
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -41,7 +41,11 @@ namespace ReactiveUI.Validation.ValidationBindings
         /// <param name="view">View instance.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property.</param>
-        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <param name="strict">Indicates if the ViewModel property to find is unique.</param>
         /// <returns>Returns a validation component.</returns>
         public static IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(
@@ -166,7 +170,11 @@ namespace ReactiveUI.Validation.ValidationBindings
         /// <param name="view">View instance.</param>
         /// <param name="viewModelHelperProperty">ViewModel's ValidationHelper property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <returns>Returns a validation component.</returns>
         public static IValidationBinding ForValidationHelperProperty<TView, TViewModel, TViewProperty>(
             TView view,
@@ -319,7 +327,11 @@ namespace ReactiveUI.Validation.ValidationBindings
         /// <typeparam name="TViewProperty">View property type.</typeparam>
         /// <param name="view">View instance.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
+        /// <param name="formatter">
+        /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
+        /// default value, implement <see cref="IValidationTextFormatter{TOut}"/> and register an instance of
+        /// IValidationTextFormatter&lt;string&gt; into Splat.Locator.
+        /// </param>
         /// <returns>Returns a validation component.</returns>
         public static IValidationBinding ForViewModel<TView, TViewModel, TViewProperty>(
             TView view,

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -68,7 +68,8 @@ namespace ReactiveUI.Validation.ValidationBindings
                 throw new ArgumentNullException(nameof(viewProperty));
             }
 
-            formatter ??= SingleLineFormatter.Default;
+            formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+                          SingleLineFormatter.Default;
 
             var vcObs = view
                 .WhenAnyValue(v => v.ViewModel)
@@ -165,7 +166,7 @@ namespace ReactiveUI.Validation.ValidationBindings
         /// <param name="view">View instance.</param>
         /// <param name="viewModelHelperProperty">ViewModel's ValidationHelper property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter.</param>
+        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
         /// <returns>Returns a validation component.</returns>
         public static IValidationBinding ForValidationHelperProperty<TView, TViewModel, TViewProperty>(
             TView view,
@@ -190,7 +191,8 @@ namespace ReactiveUI.Validation.ValidationBindings
                 throw new ArgumentNullException(nameof(viewProperty));
             }
 
-            formatter ??= SingleLineFormatter.Default;
+            formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+                          SingleLineFormatter.Default;
 
             var vcObs = view
                 .WhenAnyValue(v => v.ViewModel)
@@ -317,7 +319,7 @@ namespace ReactiveUI.Validation.ValidationBindings
         /// <typeparam name="TViewProperty">View property type.</typeparam>
         /// <param name="view">View instance.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
-        /// <param name="formatter">Validation formatter.</param>
+        /// <param name="formatter">Validation formatter. Defaults to the <see cref="SingleLineFormatter"/>.</param>
         /// <returns>Returns a validation component.</returns>
         public static IValidationBinding ForViewModel<TView, TViewModel, TViewProperty>(
             TView view,
@@ -336,7 +338,8 @@ namespace ReactiveUI.Validation.ValidationBindings
                 throw new ArgumentNullException(nameof(view));
             }
 
-            formatter ??= SingleLineFormatter.Default;
+            formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+                          SingleLineFormatter.Default;
 
             var vcObs = view
                 .WhenAnyValue(v => v.ViewModel)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Since https://github.com/reactiveui/ReactiveUI.Validation/pull/103 we support custom `IValidationTextFormatter`s in `BindValidation`, so this PR adds a way to override the default validation text formatter. With these changes, we are still using `SingleLineFormatter.Default`, but also try to resolve the `IValidationTextFormatter<string>` from `Locator.Current`. Also, this PR adds a few tests for validation bindings used in platform-specific `BindValidation` extension methods (e.g. in [`ViewForExtensions` in Android](https://github.com/reactiveui/ReactiveUI.Validation/blob/main/src/ReactiveUI.Validation/Platforms/Android/ViewForExtensions.cs#L47)) and improves XML docs.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, there is no way to override the default validation text formatter.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, in order to override the global validation text formatter, one should write the following code:

```cs
Locator.CurrentMutable.RegisterConstant(typeof(IValidationTextFormatter<string>), new AwesomeValidationFormatter());
```

We are using a similar approach in e.g. [Akavache](https://github.com/reactiveui/Akavache/blob/9c1b132760b074fc96e46360a899a5dc708b8d35/src/Akavache.Core/BlobCache/InMemoryBlobCache.cs#L444), so probably this should be a good way to go.

**What might this PR break?**

Nothing.
