### PR TITLE
Support Binding to IReactiveObject's

### DIFF
--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -121,29 +121,29 @@ namespace ReactiveUI.Validation.Extensions
     public static class ValidatableViewModelExtensions
     {
         public static System.IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Obsolete("This overload is planned for future removal. Consider using either the overload t" +
             "hat accepts a Func<TViewModel, string> as the messageFunc parameter, or the over" +
             "load that accepts a string.")]
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, string message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Obsolete("This overload is planned for future removal. Consider using either the overload t" +
             "hat accepts a Func<TViewModel, string> as the messageFunc parameter, or the over" +
             "load that accepts a string.")]
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, string message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModelProp, bool> isPropertyValid, System.Func<TViewModelProp, string> message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModelProp, bool> isPropertyValid, string message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
     public static class ValidationContextExtensions
     {
@@ -158,18 +158,18 @@ namespace ReactiveUI.Validation.Extensions
         public static System.IDisposable BindToDirect<TTarget, TValue>(System.IObservable<TValue> @this, TTarget target, System.Linq.Expressions.Expression viewExpression) { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Obsolete("This method is no longer required, BindValidation now supports multiple validatio" +
             "ns.")]
         public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
 }
 namespace ReactiveUI.Validation.Formatters.Abstractions
@@ -274,21 +274,21 @@ namespace ReactiveUI.Validation.ValidationBindings
         public void Dispose() { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>, System.Collections.Generic.IList<TOut>> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter, bool strict = true)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null, bool strict = true)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Action<ReactiveUI.Validation.States.ValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TOut>(TView view, System.Action<TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -121,29 +121,29 @@ namespace ReactiveUI.Validation.Extensions
     public static class ValidatableViewModelExtensions
     {
         public static System.IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Obsolete("This overload is planned for future removal. Consider using either the overload t" +
             "hat accepts a Func<TViewModel, string> as the messageFunc parameter, or the over" +
             "load that accepts a string.")]
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, string message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Obsolete("This overload is planned for future removal. Consider using either the overload t" +
             "hat accepts a Func<TViewModel, string> as the messageFunc parameter, or the over" +
             "load that accepts a string.")]
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, System.Func<TViewModel, bool, string> messageFunc)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, string message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModelProp, bool> isPropertyValid, System.Func<TViewModelProp, string> message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModelProp, bool> isPropertyValid, string message)
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
     public static class ValidationContextExtensions
     {
@@ -158,18 +158,18 @@ namespace ReactiveUI.Validation.Extensions
         public static System.IDisposable BindToDirect<TTarget, TValue>(System.IObservable<TValue> @this, TTarget target, System.Linq.Expressions.Expression viewExpression) { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Obsolete("This method is no longer required, BindValidation now supports multiple validatio" +
             "ns.")]
         public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
 }
 namespace ReactiveUI.Validation.Formatters.Abstractions
@@ -274,21 +274,21 @@ namespace ReactiveUI.Validation.ValidationBindings
         public void Dispose() { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>, System.Collections.Generic.IList<TOut>> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter, bool strict = true)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null, bool strict = true)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Action<ReactiveUI.Validation.States.ValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TOut>(TView view, System.Action<TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
-            where TViewModel : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/Models/ISampleViewModel.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/ISampleViewModel.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Validation.Abstractions;
+
+namespace ReactiveUI.Validation.Tests.Models
+{
+    /// <summary>
+    /// Sample abstract view model that implements <see cref="IReactiveObject" />.
+    /// </summary>
+    public interface ISampleViewModel : IReactiveObject, IValidatableViewModel
+    {
+        /// <summary>
+        /// Gets or sets the name property used for testing.
+        /// </summary>
+        string Name { get; set; }
+    }
+}

--- a/src/ReactiveUI.Validation.Tests/Models/SampleView.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/SampleView.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Validation.Tests.Models
+{
+    /// <summary>
+    /// Sample view that implements the <see cref="IViewFor{T}" /> interface, where T is the
+    /// <see cref="ISampleViewModel" /> type parameter declared as an interface.
+    /// </summary>
+    public class SampleView : IViewFor<ISampleViewModel>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SampleView"/> class.
+        /// </summary>
+        /// <param name="viewModel">
+        /// ViewModel instance the implements <see cref="ISampleViewModel"/>.
+        /// </param>
+        public SampleView(ISampleViewModel viewModel) => ViewModel = viewModel;
+
+        /// <summary>
+        /// Gets or sets the view model of this particular view.
+        /// </summary>
+        public ISampleViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name view property.
+        /// </summary>
+        public string NameLabel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name error text.
+        /// </summary>
+        public string NameErrorLabel { get; set; }
+
+        /// <inheritdoc />
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (ISampleViewModel)value;
+        }
+    }
+}

--- a/src/ReactiveUI.Validation.Tests/Models/SampleViewModel.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/SampleViewModel.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Reactive.Concurrency;
 using ReactiveUI.Validation.Helpers;
 
 namespace ReactiveUI.Validation.Tests.Models
@@ -13,6 +14,14 @@ namespace ReactiveUI.Validation.Tests.Models
     public class SampleViewModel : ReactiveValidationObject<SampleViewModel>, ISampleViewModel
     {
         private string _name;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SampleViewModel"/> class.
+        /// </summary>
+        public SampleViewModel()
+            : base(ImmediateScheduler.Instance)
+        {
+        }
 
         /// <summary>
         /// Gets or sets the property that implements <see cref="IReactiveNotifyPropertyChanged{TSender}" />.

--- a/src/ReactiveUI.Validation.Tests/Models/SampleViewModel.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/SampleViewModel.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Validation.Helpers;
+
+namespace ReactiveUI.Validation.Tests.Models
+{
+    /// <summary>
+    /// Sample view model that implements <see cref="ISampleViewModel" />.
+    /// </summary>
+    public class SampleViewModel : ReactiveValidationObject<SampleViewModel>, ISampleViewModel
+    {
+        private string _name;
+
+        /// <summary>
+        /// Gets or sets the property that implements <see cref="IReactiveNotifyPropertyChanged{TSender}" />.
+        /// </summary>
+        public string Name
+        {
+            get => _name;
+            set => this.RaiseAndSetIfChanged(ref _name, value);
+        }
+    }
+}

--- a/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
@@ -477,6 +477,35 @@ namespace ReactiveUI.Validation.Tests
             Assert.Equal(nameErrorMessage, view.NameErrorLabel);
         }
 
+        /// <summary>
+        /// Verifies that we support creating validation rules from interfaces, and also
+        /// bindings to <see cref="IViewFor" /> with interface as type argument.
+        /// </summary>
+        [Fact]
+        public void ShouldSupportBindingToInterfaces()
+        {
+            const string nameErrorMessage = "Name shouldn't be empty.";
+            var view = new SampleView(new SampleViewModel());
+
+            view.ViewModel.ValidationRule(
+                viewModel => viewModel.Name,
+                name => !string.IsNullOrWhiteSpace(name),
+                nameErrorMessage);
+
+            view.Bind(view.ViewModel, x => x.Name, x => x.NameLabel);
+            view.BindValidation(view.ViewModel, x => x.Name, x => x.NameErrorLabel);
+
+            Assert.False(view.ViewModel.ValidationContext.IsValid);
+            Assert.Equal(1, view.ViewModel.ValidationContext.Validations.Count);
+            Assert.NotEmpty(view.NameErrorLabel);
+            Assert.Equal(nameErrorMessage, view.NameErrorLabel);
+
+            view.ViewModel.Name = "Saitama";
+
+            Assert.True(view.ViewModel.ValidationContext.IsValid);
+            Assert.Empty(view.NameErrorLabel);
+        }
+
         private class ConstFormatter : IValidationTextFormatter<string>
         {
             private readonly string _text;

--- a/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, TViewModelProp>> viewModelProperty,
             Func<TViewModelProp, bool> isPropertyValid,
             string message)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -80,7 +80,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, TViewModelProp>> viewModelProperty,
             Func<TViewModelProp, bool> isPropertyValid,
             Func<TViewModelProp, string> message)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -130,7 +130,7 @@ namespace ReactiveUI.Validation.Extensions
             this TViewModel viewModel,
             Func<TViewModel, IObservable<bool>> viewModelObservableProperty,
             string message)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -170,7 +170,7 @@ namespace ReactiveUI.Validation.Extensions
             this TViewModel viewModel,
             Func<TViewModel, IObservable<bool>> viewModelObservableProperty,
             Func<TViewModel, string> messageFunc)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -212,7 +212,7 @@ namespace ReactiveUI.Validation.Extensions
             this TViewModel viewModel,
             Func<TViewModel, IObservable<bool>> viewModelObservableProperty,
             Func<TViewModel, bool, string> messageFunc)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -255,7 +255,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, TViewModelProp>> viewModelProperty,
             Func<TViewModel, IObservable<bool>> viewModelObservableProperty,
             string message)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -303,7 +303,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, TViewModelProp>> viewModelProperty,
             Func<TViewModel, IObservable<bool>> viewModelObservableProperty,
             Func<TViewModel, string> messageFunc)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -353,7 +353,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TViewModel, TViewModelProp>> viewModelProperty,
             Func<TViewModel, IObservable<bool>> viewModelObservableProperty,
             Func<TViewModel, bool, string> messageFunc)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -389,7 +389,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <param name="viewModel">ViewModel instance.</param>
         /// <returns>Returns true if the ValidationContext is valid, otherwise false.</returns>
         public static IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : IReactiveObject, IValidatableViewModel
         {
             if (viewModel == null)
             {

--- a/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
@@ -49,7 +49,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -94,7 +94,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {
@@ -135,7 +135,7 @@ namespace ReactiveUI.Validation.Extensions
             TViewModel viewModel,
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
             where TView : IViewFor<TViewModel>
         {
             if (viewModel is null)
@@ -175,7 +175,7 @@ namespace ReactiveUI.Validation.Extensions
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             if (viewModel is null)
             {

--- a/src/ReactiveUI.Validation/Platforms/Android/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Platforms/Android/ViewForExtensions.cs
@@ -47,7 +47,7 @@ namespace ReactiveUI.Validation.Platforms.Android
             TextInputLayout viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
                           SingleLineFormatter.Default;
@@ -85,7 +85,7 @@ namespace ReactiveUI.Validation.Platforms.Android
             TextInputLayout viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
                           SingleLineFormatter.Default;
@@ -120,7 +120,7 @@ namespace ReactiveUI.Validation.Platforms.Android
             TextInputLayout viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
                           SingleLineFormatter.Default;

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -55,7 +55,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             IValidationTextFormatter<string>? formatter = null,
             bool strict = true)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             if (view is null)
             {
@@ -118,7 +118,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             IValidationTextFormatter<TOut> formatter,
             bool strict = true)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             if (view is null)
             {
@@ -184,7 +184,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             if (view is null)
             {
@@ -239,7 +239,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             Action<ValidationState, TOut> action,
             IValidationTextFormatter<TOut> formatter)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             if (view is null)
             {
@@ -295,7 +295,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             Action<TOut> action,
             IValidationTextFormatter<TOut> formatter)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             if (view is null)
             {
@@ -344,7 +344,7 @@ namespace ReactiveUI.Validation.ValidationBindings
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
-            where TViewModel : ReactiveObject, IValidatableViewModel
+            where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
             if (view is null)
             {


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Currently, ReactiveUI.Validation doesn't support creating `ValidationRule`s for objects that don't inherit from a `ReactiveObject`. Also, binding to `IViewFor<IReactiveObject>` via `BindValidation` isn't supported. However, there may be cases, when one needs to use an interface as a type parameter in `IViewFor` (e.g. `IViewFor<IViewModel>`). Also, some folks may decide to use a custom `IReactiveObject` implementation e.g. in case if they use ReactiveUI with MvvmCross, Prism, etc. So this PR changes the generic type constraint from `: ReactiveObject` to `: class, IReactiveObject` and adds a few tests for this.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, ReactiveUI.Validation doesn't support binding to `IReactiveObject`s.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, ReactiveUI.Validation supports binding to `IReactiveObject`s.

**What might this PR break?**

Nothing.