### PR TITLE
feature: Improved IDisposable Handling, Possibility to Change Validation Rules Dynamically

### DIFF
--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -114,6 +114,7 @@ namespace ReactiveUI.Validation.Contexts
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public bool GetIsValid() { }
+        public void Remove(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
     }
 }
 namespace ReactiveUI.Validation.Extensions
@@ -201,7 +202,7 @@ namespace ReactiveUI.Validation.Helpers
     }
     public class ValidationHelper : ReactiveUI.ReactiveObject, System.IDisposable
     {
-        public ValidationHelper(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
+        public ValidationHelper(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation, System.IDisposable? cleanup = null) { }
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Message { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationChanged { get; }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -114,6 +114,7 @@ namespace ReactiveUI.Validation.Contexts
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public bool GetIsValid() { }
+        public void Remove(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
     }
 }
 namespace ReactiveUI.Validation.Extensions
@@ -201,7 +202,7 @@ namespace ReactiveUI.Validation.Helpers
     }
     public class ValidationHelper : ReactiveUI.ReactiveObject, System.IDisposable
     {
-        public ValidationHelper(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
+        public ValidationHelper(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation, System.IDisposable? cleanup = null) { }
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Message { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationChanged { get; }

--- a/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
+++ b/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
@@ -251,16 +251,17 @@ namespace ReactiveUI.Validation.Tests
 
             Assert.Equal(1, view.ViewModel.ValidationContext.Validations.Count);
             Assert.False(view.ViewModel.ValidationContext.IsValid);
-            Assert.Equal(2, arguments.Count);
-            Assert.Equal(string.Empty, arguments[0].PropertyName);
-            Assert.Equal(nameof(view.ViewModel.Name), arguments[1].PropertyName);
+            Assert.True(view.ViewModel.HasErrors);
+            Assert.Equal(1, arguments.Count);
+            Assert.Equal(nameof(view.ViewModel.Name), arguments[0].PropertyName);
 
             helper.Dispose();
 
             Assert.Equal(0, view.ViewModel.ValidationContext.Validations.Count);
             Assert.True(view.ViewModel.ValidationContext.IsValid);
-            Assert.Equal(3, arguments.Count);
-            Assert.Equal(string.Empty, arguments[2].PropertyName);
+            Assert.False(view.ViewModel.HasErrors);
+            Assert.Equal(2, arguments.Count);
+            Assert.Equal(nameof(view.ViewModel.Name), arguments[1].PropertyName);
         }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
+++ b/src/ReactiveUI.Validation.Tests/NotifyDataErrorInfoTests.cs
@@ -3,12 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
 using ReactiveUI.Validation.Components;
 using ReactiveUI.Validation.Extensions;
+using ReactiveUI.Validation.Helpers;
 using ReactiveUI.Validation.Tests.Models;
 using Xunit;
 
@@ -226,6 +228,39 @@ namespace ReactiveUI.Validation.Tests
             Assert.Equal(nameof(viewModel.Name), arguments[2].PropertyName);
             Assert.Equal(nameof(viewModel.OtherName), arguments[3].PropertyName);
             Assert.True(viewModel.HasErrors);
+        }
+
+        /// <summary>
+        /// Verifies that we detach and dispose the disposable validations once the
+        /// <see cref="ValidationHelper"/> is disposed. Also, here we ensure that
+        /// the property change subscriptions are unsubscribed.
+        /// </summary>
+        [Fact]
+        public void ShouldDetachAndDisposeTheComponentWhenValidationHelperDisposes()
+        {
+            var view = new IndeiTestView(new IndeiTestViewModel { Name = string.Empty });
+            var arguments = new List<DataErrorsChangedEventArgs>();
+            view.ViewModel.ErrorsChanged += (sender, args) => arguments.Add(args);
+
+            var helper = view
+                .ViewModel
+                .ValidationRule(
+                    viewModel => viewModel.Name,
+                    name => !string.IsNullOrWhiteSpace(name),
+                    "Name shouldn't be empty.");
+
+            Assert.Equal(1, view.ViewModel.ValidationContext.Validations.Count);
+            Assert.False(view.ViewModel.ValidationContext.IsValid);
+            Assert.Equal(2, arguments.Count);
+            Assert.Equal(string.Empty, arguments[0].PropertyName);
+            Assert.Equal(nameof(view.ViewModel.Name), arguments[1].PropertyName);
+
+            helper.Dispose();
+
+            Assert.Equal(0, view.ViewModel.ValidationContext.Validations.Count);
+            Assert.True(view.ViewModel.ValidationContext.IsValid);
+            Assert.Equal(3, arguments.Count);
+            Assert.Equal(string.Empty, arguments[2].PropertyName);
         }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
@@ -506,6 +506,36 @@ namespace ReactiveUI.Validation.Tests
             Assert.Empty(view.NameErrorLabel);
         }
 
+        /// <summary>
+        /// Verifies that we detach and dispose the disposable validations once the
+        /// <see cref="ValidationHelper"/> is disposed. Also, here we ensure that
+        /// the property change subscriptions are unsubscribed.
+        /// </summary>
+        [Fact]
+        public void ShouldDetachAndDisposeTheComponentWhenValidationHelperDisposes()
+        {
+            var view = new TestView(new TestViewModel { Name = string.Empty });
+            var helper = view
+                .ViewModel
+                .ValidationRule(
+                    viewModel => viewModel.Name,
+                    name => !string.IsNullOrWhiteSpace(name),
+                    "Name shouldn't be empty.");
+
+            view.Bind(view.ViewModel, x => x.Name, x => x.NameLabel);
+            view.BindValidation(view.ViewModel, x => x.Name, x => x.NameErrorLabel);
+
+            Assert.Equal(1, view.ViewModel.ValidationContext.Validations.Count);
+            Assert.False(view.ViewModel.ValidationContext.IsValid);
+            Assert.NotEmpty(view.NameErrorLabel);
+
+            helper.Dispose();
+
+            Assert.Equal(0, view.ViewModel.ValidationContext.Validations.Count);
+            Assert.True(view.ViewModel.ValidationContext.IsValid);
+            Assert.Empty(view.NameErrorLabel);
+        }
+
         private class ConstFormatter : IValidationTextFormatter<string>
         {
             private readonly string _text;

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -145,6 +145,12 @@ namespace ReactiveUI.Validation.Contexts
         public void Add(IValidationComponent validation) => _validationSource.Add(validation);
 
         /// <summary>
+        /// Removes a validation from the validations collection.
+        /// </summary>
+        /// <param name="validation">Validation component to be removed from the collection.</param>
+        public void Remove(IValidationComponent validation) => _validationSource.Remove(validation);
+
+        /// <summary>
         /// Returns if the whole context is valid checking all the validations.
         /// </summary>
         /// <returns>Returns true if the <see cref="ValidationContext"/> is valid, otherwise false.</returns>

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -148,7 +148,13 @@ namespace ReactiveUI.Validation.Contexts
         /// Removes a validation from the validations collection.
         /// </summary>
         /// <param name="validation">Validation component to be removed from the collection.</param>
-        public void Remove(IValidationComponent validation) => _validationSource.Remove(validation);
+        public void Remove(IValidationComponent validation) => _validationSource.Edit(list =>
+        {
+            if (list.Contains(validation))
+            {
+                list.Remove(validation);
+            }
+        });
 
         /// <summary>
         /// Returns if the whole context is valid checking all the validations.

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -67,7 +67,9 @@ namespace ReactiveUI.Validation.Contexts
                 .Select(validations =>
                     validations
                         .Select(v => v.ValidationStatusChange)
-                        .Merge())
+                        .Merge()
+                        .Select(_ => Unit.Default)
+                        .StartWith(Unit.Default))
                 .Switch()
                 .Select(_ => GetIsValid())
                 .Multicast(_validSubject);

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -25,6 +25,7 @@ namespace ReactiveUI.Validation.Helpers
     /// <typeparam name="TViewModel">The parent view model.</typeparam>
     public abstract class ReactiveValidationObject<TViewModel> : ReactiveObject, IValidatableViewModel, INotifyDataErrorInfo
     {
+        private readonly HashSet<string> _mentionedPropertyNames = new HashSet<string>();
         private bool _hasErrors;
 
         /// <summary>
@@ -95,18 +96,30 @@ namespace ReactiveUI.Validation.Helpers
         /// event, and then raises the <see cref="ErrorsChanged" /> event. This behaviour is required by WPF, see:
         /// https://stackoverflow.com/questions/24518520/ui-not-calling-inotifydataerrorinfo-geterrors/24837028.
         /// </summary>
+        /// <remarks>
+        /// WPF doesn't understand string.Empty as an argument for the <see cref="ErrorsChanged"/>
+        /// event, so we are sending <see cref="ErrorsChanged"/> notifications for every saved property.
+        /// This is required for e.g. cases when a <see cref="IValidationComponent"/> is disposed and
+        /// detached from the <see cref="ValidationContext"/>, and we'd like to mark all invalid
+        /// properties as valid (because the thing that validates them no longer exists).
+        /// </remarks>
         private void OnValidationStatusChange(ValidationState state)
         {
             HasErrors = !ValidationContext.GetIsValid();
-            if (state.Component is IPropertyValidationComponent<TViewModel> propertyValidationComponent &&
-                propertyValidationComponent.PropertyCount == 1)
+            if (state.Component is IPropertyValidationComponent<TViewModel> propertyValidationComponent)
             {
-                var propertyName = propertyValidationComponent.Properties.First();
-                RaiseErrorsChanged(propertyName);
+                foreach (var propertyName in propertyValidationComponent.Properties)
+                {
+                    RaiseErrorsChanged(propertyName);
+                    _mentionedPropertyNames.Add(propertyName);
+                }
             }
             else
             {
-                RaiseErrorsChanged();
+                foreach (var propertyName in _mentionedPropertyNames)
+                {
+                    RaiseErrorsChanged(propertyName);
+                }
             }
         }
     }

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -39,7 +39,8 @@ namespace ReactiveUI.Validation.Helpers
                 .ToCollection()
                 .Select(components => components
                     .Select(component => component.ValidationStatusChange)
-                    .Merge())
+                    .Merge()
+                    .StartWith(new ValidationState(true, string.Empty, ValidationContext)))
                 .Switch()
                 .Subscribe(OnValidationStatusChange);
         }

--- a/src/ReactiveUI.Validation/Helpers/ValidationHelper.cs
+++ b/src/ReactiveUI.Validation/Helpers/ValidationHelper.cs
@@ -41,7 +41,7 @@ namespace ReactiveUI.Validation.Helpers
 
             _message = _validation.ValidationStatusChange
                 .Select(v => v.Text)
-                .ToProperty(this, nameof(Message));
+                .ToProperty<ValidationHelper, ValidationText>(this, nameof(Message));
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR allows `IValidationComponent`s to be detached from a `ValidationContext`.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

As described in https://github.com/reactiveui/ReactiveUI.Validation/issues/71, currently there is no way to detach an `IValidationComponent` if it is attached to a `ValidationContext`. Although it is possible to write `WhenAnyValue`-based `ValidationRule`s that respect the observable and mutable state of a validated view model, sometimes it may be easier to just remove and dispose of a specific `IValidationComponent`.

Currently there is no way to dispose of a `BasePropertyValidation` and of a `ModelObservableValidation`, see https://github.com/reactiveui/ReactiveUI.Validation/blob/main/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs#L58 If we call the `ValidationRule()` extension method, a new instance of a disposable `IValidationComponent` is created and attached to the `ValidationContext`. Notably, the disposable validation component is never disposed of. Also, currently, there is no way to dispose of the validation component manually, the `IValidationComponent` interface doesn't implement `IDisposable`, and the `ValidationHelper` doesn't dispose of the underlying `IValidationComponent`.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, if we dispose of the `ValidationHelper` that is returned by a call to `ValidationRule`, it will dispose of an underlying `BasePropertyValidation` or a `ModelObservableValidation` automatically. Also, it will detach the `IValidationComponent` from the `ValidationContext` before disposal. Also, it is now possible to detach any validation components manually from the validation context. We are now accessing the `ReadOnlyObservableCollection<IValidationComponent>` in a reactive fashion both in our `INotifyDataErrorInfo` implementation, and in the `BindValidation` extension method. This allows putting `ValidationRule`s into a `WhenActivated` block e.g.

```cs
this.WhenActivated(disposables =>
{
    this.ValidationRule(
        x => x.UserName,
        name => !string.IsNullOrWhiteSpace(name),
        "UserName shouldn't be null or white space.")
        .DisposeWith(_compositeDisposable);
});
```

**What might this PR break?**

Hopefully nothing.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

Currently, this is a WIP PR. Reactivity in `BindValidation` isn't fully implemented yet.