### PR TITLE
feature: Deprecate ReactiveValidationObject<T> in Favor of Just ReactiveValidationObject

### DIFF
--- a/samples/LoginApp/ViewModels/SignUpViewModel.cs
+++ b/samples/LoginApp/ViewModels/SignUpViewModel.cs
@@ -20,7 +20,7 @@ namespace LoginApp.ViewModels
     /// <summary>
     /// A view model which shows controls to create an account.
     /// </summary>
-    public class SignUpViewModel : ReactiveValidationObject<SignUpViewModel>, IRoutableViewModel, IActivatableViewModel
+    public class SignUpViewModel : ReactiveValidationObject, IRoutableViewModel, IActivatableViewModel
     {
         private readonly IUserDialogs _dialogs;
 

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -32,13 +32,17 @@ namespace ReactiveUI.Validation.Comparators
 }
 namespace ReactiveUI.Validation.Components.Abstractions
 {
-    public interface IPropertyValidationComponent<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
-    public interface IValidatesProperties<TViewModel>
+    public interface IPropertyValidationComponent : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
+    public interface IPropertyValidationComponent<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
+    public interface IValidatesProperties
     {
         System.Collections.Generic.IEnumerable<string> Properties { get; }
         int PropertyCount { get; }
-        bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
         bool ContainsPropertyName(string propertyName, bool exclusively = false);
+    }
+    public interface IValidatesProperties<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties
+    {
+        bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
     }
     public interface IValidationComponent
     {
@@ -49,7 +53,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
 }
 namespace ReactiveUI.Validation.Components
 {
-    public abstract class BasePropertyValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class BasePropertyValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
         protected BasePropertyValidation() { }
         public bool IsValid { get; }
@@ -72,7 +76,7 @@ namespace ReactiveUI.Validation.Components
         protected override void Dispose(bool disposing) { }
         protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
     }
-    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
         protected ModelObservableValidationBase(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
         public ModelObservableValidationBase(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
@@ -198,7 +202,7 @@ namespace ReactiveUI.Validation.Formatters
 }
 namespace ReactiveUI.Validation.Helpers
 {
-    public abstract class ReactiveValidationObject<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo
+    public abstract class ReactiveValidationObject : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo
     {
         protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public bool HasErrors { get; }
@@ -206,6 +210,12 @@ namespace ReactiveUI.Validation.Helpers
         public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs>? ErrorsChanged;
         public virtual System.Collections.IEnumerable GetErrors(string propertyName) { }
         protected void RaiseErrorsChanged(string propertyName = "") { }
+    }
+    [System.Obsolete("The type parameters are no longer required. Use the non-generic version of Reacti" +
+        "veValidationObject.")]
+    public abstract class ReactiveValidationObject<TViewModel> : ReactiveUI.Validation.Helpers.ReactiveValidationObject
+    {
+        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
     }
     public class ValidationHelper : ReactiveUI.ReactiveObject, System.IDisposable
     {

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -32,13 +32,17 @@ namespace ReactiveUI.Validation.Comparators
 }
 namespace ReactiveUI.Validation.Components.Abstractions
 {
-    public interface IPropertyValidationComponent<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
-    public interface IValidatesProperties<TViewModel>
+    public interface IPropertyValidationComponent : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
+    public interface IPropertyValidationComponent<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
+    public interface IValidatesProperties
     {
         System.Collections.Generic.IEnumerable<string> Properties { get; }
         int PropertyCount { get; }
-        bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
         bool ContainsPropertyName(string propertyName, bool exclusively = false);
+    }
+    public interface IValidatesProperties<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties
+    {
+        bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
     }
     public interface IValidationComponent
     {
@@ -49,7 +53,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
 }
 namespace ReactiveUI.Validation.Components
 {
-    public abstract class BasePropertyValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class BasePropertyValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
         protected BasePropertyValidation() { }
         public bool IsValid { get; }
@@ -72,7 +76,7 @@ namespace ReactiveUI.Validation.Components
         protected override void Dispose(bool disposing) { }
         protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
     }
-    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
         protected ModelObservableValidationBase(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
         public ModelObservableValidationBase(TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
@@ -198,7 +202,7 @@ namespace ReactiveUI.Validation.Formatters
 }
 namespace ReactiveUI.Validation.Helpers
 {
-    public abstract class ReactiveValidationObject<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo
+    public abstract class ReactiveValidationObject : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo
     {
         protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public bool HasErrors { get; }
@@ -206,6 +210,12 @@ namespace ReactiveUI.Validation.Helpers
         public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs>? ErrorsChanged;
         public virtual System.Collections.IEnumerable GetErrors(string propertyName) { }
         protected void RaiseErrorsChanged(string propertyName = "") { }
+    }
+    [System.Obsolete("The type parameters are no longer required. Use the non-generic version of Reacti" +
+        "veValidationObject.")]
+    public abstract class ReactiveValidationObject<TViewModel> : ReactiveUI.Validation.Helpers.ReactiveValidationObject
+    {
+        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
     }
     public class ValidationHelper : ReactiveUI.ReactiveObject, System.IDisposable
     {

--- a/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
@@ -3,13 +3,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace ReactiveUI.Validation.Components.Abstractions
 {
     /// <summary>
-    /// a component specifically validating one or more properties.
+    /// A component specifically validating one or more typed properties.
     /// </summary>
     /// <typeparam name="TViewModel">The validation target.</typeparam>
-    public interface IPropertyValidationComponent<TViewModel> : IValidationComponent, IValidatesProperties<TViewModel>
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:FileHeaderFileNameDocumentationMustMatchTypeName", Justification = "Same type just generic.")]
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same type just generic.")]
+    public interface IPropertyValidationComponent<TViewModel> : IPropertyValidationComponent, IValidatesProperties<TViewModel>
+    {
+    }
+
+    /// <summary>
+    /// A component specifically validating one or more untyped properties.
+    /// </summary>
+    public interface IPropertyValidationComponent : IValidationComponent, IValidatesProperties
     {
     }
 }

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
@@ -5,15 +5,33 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
 namespace ReactiveUI.Validation.Components.Abstractions
 {
     /// <summary>
-    /// Interface marking a validation component that validates specific properties.
+    /// Interface marking a validation component that validates specific typed properties.
     /// </summary>
     /// <typeparam name="TViewModel">The validation target.</typeparam>
-    public interface IValidatesProperties<TViewModel>
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:FileHeaderFileNameDocumentationMustMatchTypeName", Justification = "Same type just generic.")]
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same type just generic.")]
+    public interface IValidatesProperties<TViewModel> : IValidatesProperties
+    {
+        /// <summary>
+        /// Determine if a property name is actually contained within this.
+        /// </summary>
+        /// <typeparam name="TProp">Any type.</typeparam>
+        /// <param name="propertyExpression">ViewModel property.</param>
+        /// <param name="exclusively">Indicates if the property to find is unique.</param>
+        /// <returns>Returns true if it contains the property, otherwise false.</returns>
+        bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
+    }
+
+    /// <summary>
+    /// Interface marking a validation component that validates specific untyped properties.
+    /// </summary>
+    public interface IValidatesProperties
     {
         /// <summary>
         /// Gets the total number of properties referenced.
@@ -24,15 +42,6 @@ namespace ReactiveUI.Validation.Components.Abstractions
         /// Gets the properties associated with this validation component.
         /// </summary>
         IEnumerable<string> Properties { get; }
-
-        /// <summary>
-        /// Determine if a property name is actually contained within this.
-        /// </summary>
-        /// <typeparam name="TProp">Any type.</typeparam>
-        /// <param name="propertyExpression">ViewModel property.</param>
-        /// <param name="exclusively">Indicates if the property to find is unique.</param>
-        /// <returns>Returns true if it contains the property, otherwise false.</returns>
-        bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
 
         /// <summary>
         /// Determine if a property name is actually contained within this.

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -20,16 +21,34 @@ using ReactiveUI.Validation.States;
 namespace ReactiveUI.Validation.Helpers
 {
     /// <summary>
-    /// Base class for ReactiveObjects that support INotifyDataErrorInfo validation.
+    /// Base class for ReactiveObjects that support <see cref="INotifyDataErrorInfo"/> validation.
     /// </summary>
     /// <typeparam name="TViewModel">The parent view model.</typeparam>
-    public abstract class ReactiveValidationObject<TViewModel> : ReactiveObject, IValidatableViewModel, INotifyDataErrorInfo
+    [Obsolete("The type parameters are no longer required. Use the non-generic version of ReactiveValidationObject.")]
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:FileHeaderFileNameDocumentationMustMatchTypeName", Justification = "Same class just generic.")]
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just generic.")]
+    public abstract class ReactiveValidationObject<TViewModel> : ReactiveValidationObject
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReactiveValidationObject{TViewModel}"/> class.
+        /// </summary>
+        /// <param name="scheduler">Scheduler for OAPHs and for the the ValidationContext.</param>
+        protected ReactiveValidationObject(IScheduler? scheduler = null)
+            : base(scheduler)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Base class for ReactiveObjects that support <see cref="INotifyDataErrorInfo"/> validation.
+    /// </summary>
+    public abstract class ReactiveValidationObject : ReactiveObject, IValidatableViewModel, INotifyDataErrorInfo
     {
         private readonly HashSet<string> _mentionedPropertyNames = new HashSet<string>();
         private bool _hasErrors;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ReactiveValidationObject{TViewModel}"/> class.
+        /// Initializes a new instance of the <see cref="ReactiveValidationObject"/> class.
         /// </summary>
         /// <param name="scheduler">Scheduler for OAPHs and for the the ValidationContext.</param>
         protected ReactiveValidationObject(IScheduler? scheduler = null)
@@ -87,9 +106,9 @@ namespace ReactiveUI.Validation.Helpers
         /// Selects validation components that are invalid.
         /// </summary>
         /// <returns>Returns the invalid property validations.</returns>
-        private IEnumerable<IPropertyValidationComponent<TViewModel>> SelectInvalidPropertyValidations() =>
+        private IEnumerable<IPropertyValidationComponent> SelectInvalidPropertyValidations() =>
             ValidationContext.Validations
-                .OfType<IPropertyValidationComponent<TViewModel>>()
+                .OfType<IPropertyValidationComponent>()
                 .Where(validation => !validation.IsValid);
 
         /// <summary>
@@ -107,7 +126,7 @@ namespace ReactiveUI.Validation.Helpers
         private void OnValidationStatusChange(ValidationState state)
         {
             HasErrors = !ValidationContext.GetIsValid();
-            if (state.Component is IPropertyValidationComponent<TViewModel> propertyValidationComponent)
+            if (state.Component is IPropertyValidationComponent propertyValidationComponent)
             {
                 foreach (var propertyName in propertyValidationComponent.Properties)
                 {


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR deprecates `ReactiveValidationObject<TViewModel>` in favor of just `ReactiveValidationObject`. The non-generic methods of core ReactiveUI.Validation interfaces were moved to the new non-generic interfaces in order to support non-generic property validation LINQ queries. This allows getting rid of type parameters in `ReactiveValidationObject` and using a bit shorter syntax.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, in order to support `INotifyDataErrorInfo` notifications, one should inherit from `ReactiveValidationObject<T>`.

```cs
// Currently, the view model type should be always used as the generic type parameter.
public class SampleViewModel : ReactiveValidationObject<SampleViewModel> { }
```

**What is the new behavior?**
<!-- If this is a feature change -->

Now, we are deprecating the syntax shown above in favor of the following syntax:

```cs
// With this PR, the syntax is more concise. 
public class SampleViewModel : ReactiveValidationObject { }
```

**What might this PR break?**

Nothing, as we are deprecating the old API and still not removing it completely.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)