### PR TITLE
refactor: Deprecate Generic IValidatesProperties<T>

### DIFF
--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -44,6 +44,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
     [System.Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
     public interface IValidatesProperties<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties
     {
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
         bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
     }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -65,6 +65,7 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
@@ -92,6 +93,7 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
@@ -124,6 +126,7 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
@@ -226,15 +229,15 @@ namespace ReactiveUI.Validation.Extensions
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1, TProperty2>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1, TProperty2>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1, TProperty2, TProperty3>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> viewModelProperty3) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1, TProperty2, TProperty3>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> viewModelProperty3) { }
     }
     public static class ViewForExtensions
     {

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -33,6 +33,7 @@ namespace ReactiveUI.Validation.Comparators
 namespace ReactiveUI.Validation.Components.Abstractions
 {
     public interface IPropertyValidationComponent : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
+    [System.Obsolete("Consider using the non-generic version of an IPropertyValidationComponent.")]
     public interface IPropertyValidationComponent<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
     public interface IValidatesProperties
     {
@@ -40,8 +41,10 @@ namespace ReactiveUI.Validation.Components.Abstractions
         int PropertyCount { get; }
         bool ContainsPropertyName(string propertyName, bool exclusively = false);
     }
+    [System.Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
     public interface IValidatesProperties<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties
     {
+        [System.Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
         bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
     }
     public interface IValidationComponent
@@ -62,6 +65,8 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
+            "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
@@ -87,6 +92,8 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
+            "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
@@ -117,6 +124,8 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
+            "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
@@ -207,21 +216,25 @@ namespace ReactiveUI.Validation.Extensions
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp, TValue>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.IObservable<TValue> viewModelObservable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
+    public static class ValidatesPropertiesExtensions
+    {
+        public static bool ContainsProperty<TViewModel, TProp>(this ReactiveUI.Validation.Components.Abstractions.IValidatesProperties validatesProperties, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false) { }
+    }
     public static class ValidationContextExtensions
     {
         public static System.IObservable<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>> ObserveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1, TProperty2>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1, TProperty2>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1, TProperty2, TProperty3>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> viewModelProperty3) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1, TProperty2, TProperty3>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> viewModelProperty3) { }
     }
     public static class ViewForExtensions
     {

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -44,6 +44,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
     [System.Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
     public interface IValidatesProperties<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties
     {
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
         bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
     }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -65,6 +65,7 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
@@ -92,6 +93,7 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
@@ -124,6 +126,7 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
@@ -226,15 +229,15 @@ namespace ReactiveUI.Validation.Extensions
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1, TProperty2>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1, TProperty2>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1, TProperty2, TProperty3>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> viewModelProperty3) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1, TProperty2, TProperty3>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> viewModelProperty3) { }
     }
     public static class ViewForExtensions
     {

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -33,6 +33,7 @@ namespace ReactiveUI.Validation.Comparators
 namespace ReactiveUI.Validation.Components.Abstractions
 {
     public interface IPropertyValidationComponent : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
+    [System.Obsolete("Consider using the non-generic version of an IPropertyValidationComponent.")]
     public interface IPropertyValidationComponent<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
     public interface IValidatesProperties
     {
@@ -40,8 +41,10 @@ namespace ReactiveUI.Validation.Components.Abstractions
         int PropertyCount { get; }
         bool ContainsPropertyName(string propertyName, bool exclusively = false);
     }
+    [System.Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
     public interface IValidatesProperties<TViewModel> : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties
     {
+        [System.Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
         bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
     }
     public interface IValidationComponent
@@ -62,6 +65,8 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
+            "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
@@ -87,6 +92,8 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
+            "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
@@ -117,6 +124,8 @@ namespace ReactiveUI.Validation.Components
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
+            "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
@@ -207,21 +216,25 @@ namespace ReactiveUI.Validation.Extensions
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp, TValue>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.IObservable<TValue> viewModelObservable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }
+    public static class ValidatesPropertiesExtensions
+    {
+        public static bool ContainsProperty<TViewModel, TProp>(this ReactiveUI.Validation.Components.Abstractions.IValidatesProperties validatesProperties, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false) { }
+    }
     public static class ValidationContextExtensions
     {
         public static System.IObservable<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>> ObserveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1, TProperty2>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1, TProperty2>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
-        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1, TProperty2, TProperty3>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> viewModelProperty3) { }
+        public static System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1, TProperty2, TProperty3>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> viewModelProperty1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> viewModelProperty2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> viewModelProperty3) { }
     }
     public static class ViewForExtensions
     {

--- a/src/ReactiveUI.Validation.Tests/ModelObservableTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ModelObservableTests.cs
@@ -179,7 +179,9 @@ namespace ReactiveUI.Validation.Tests
                     "Name shouldn't be empty.");
 
             Assert.True(component.ContainsProperty<TestViewModel, string>(model => model.Name));
+            Assert.True(component.ContainsProperty<TestViewModel, string>(model => model.Name, true));
             Assert.False(component.ContainsProperty<TestViewModel, string>(model => model.Name2));
+            Assert.False(component.ContainsProperty<TestViewModel, string>(model => model.Name2, true));
             Assert.Throws<ArgumentNullException>(() => component.ContainsProperty<TestViewModel, string>(null!));
         }
     }

--- a/src/ReactiveUI.Validation.Tests/ModelObservableTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ModelObservableTests.cs
@@ -5,6 +5,8 @@
 
 using System.Reactive.Subjects;
 using ReactiveUI.Validation.Components;
+using ReactiveUI.Validation.Components.Abstractions;
+using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Tests.Models;
 using Xunit;
 
@@ -158,6 +160,30 @@ namespace ReactiveUI.Validation.Tests
             _validState.OnNext(true);
 
             Assert.False(validation.IsValid);
+        }
+
+        /// <summary>
+        /// Verifies that we support resolving properties by expressions.
+        /// </summary>
+        [Fact]
+        public void ShouldResolveTypedProperties()
+        {
+            var viewModel = new TestViewModel { Name = string.Empty };
+            IPropertyValidationComponent propertyValidation =
+                new ObservableValidation<TestViewModel, string, string>(
+                    viewModel,
+                    model => model.Name,
+                    viewModel.WhenAnyValue(x => x.Name),
+                    state => !string.IsNullOrWhiteSpace(state),
+                    "Name shouldn't be empty.");
+
+            var containsNameProperty = propertyValidation
+                .ContainsProperty<TestViewModel, string>(model => model.Name);
+            Assert.True(containsNameProperty);
+
+            var containsName2Property = propertyValidation
+                .ContainsProperty<TestViewModel, string>(model => model.Name2);
+            Assert.False(containsName2Property);
         }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/ModelObservableTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ModelObservableTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Reactive.Subjects;
 using ReactiveUI.Validation.Components;
 using ReactiveUI.Validation.Components.Abstractions;
@@ -169,7 +170,7 @@ namespace ReactiveUI.Validation.Tests
         public void ShouldResolveTypedProperties()
         {
             var viewModel = new TestViewModel { Name = string.Empty };
-            IPropertyValidationComponent propertyValidation =
+            IPropertyValidationComponent component =
                 new ObservableValidation<TestViewModel, string, string>(
                     viewModel,
                     model => model.Name,
@@ -177,13 +178,9 @@ namespace ReactiveUI.Validation.Tests
                     state => !string.IsNullOrWhiteSpace(state),
                     "Name shouldn't be empty.");
 
-            var containsNameProperty = propertyValidation
-                .ContainsProperty<TestViewModel, string>(model => model.Name);
-            Assert.True(containsNameProperty);
-
-            var containsName2Property = propertyValidation
-                .ContainsProperty<TestViewModel, string>(model => model.Name2);
-            Assert.False(containsName2Property);
+            Assert.True(component.ContainsProperty<TestViewModel, string>(model => model.Name));
+            Assert.False(component.ContainsProperty<TestViewModel, string>(model => model.Name2));
+            Assert.Throws<ArgumentNullException>(() => component.ContainsProperty<TestViewModel, string>(null!));
         }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
@@ -17,7 +17,7 @@ namespace ReactiveUI.Validation.Tests
     /// Tests for the generic <see cref="ObservableValidation{TViewModel, TValue}"/> and for
     /// <see cref="ObservableValidation{TViewModel,TValue,TProp}"/> as well.
     /// </summary>
-    public class ModelObservableTests
+    public class ObservableValidationTests
     {
         private readonly ISubject<bool> _validState = new ReplaySubject<bool>(1);
         private readonly TestViewModel _validModel = new TestViewModel

--- a/src/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj
+++ b/src/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net472</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633</NoWarn>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
@@ -3,21 +3,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace ReactiveUI.Validation.Components.Abstractions
 {
-    /*
     /// <summary>
     /// A component specifically validating one or more typed properties.
     /// </summary>
     /// <typeparam name="TViewModel">The validation target.</typeparam>
+    [Obsolete("Consider using the non-generic version of an IPropertyValidationComponent.")]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:FileHeaderFileNameDocumentationMustMatchTypeName", Justification = "Same type just generic.")]
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same type just generic.")]
     public interface IPropertyValidationComponent<TViewModel> : IPropertyValidationComponent, IValidatesProperties<TViewModel>
     {
     }
-    */
 
     /// <summary>
     /// A component specifically validating one or more untyped properties.

--- a/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ReactiveUI.Validation.Components.Abstractions
 {
+    /*
     /// <summary>
     /// A component specifically validating one or more typed properties.
     /// </summary>
@@ -16,6 +17,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
     public interface IPropertyValidationComponent<TViewModel> : IPropertyValidationComponent, IValidatesProperties<TViewModel>
     {
     }
+    */
 
     /// <summary>
     /// A component specifically validating one or more untyped properties.

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
@@ -10,6 +10,7 @@ using System.Linq.Expressions;
 
 namespace ReactiveUI.Validation.Components.Abstractions
 {
+    /*
     /// <summary>
     /// Interface marking a validation component that validates specific typed properties.
     /// </summary>
@@ -27,6 +28,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
         /// <returns>Returns true if it contains the property, otherwise false.</returns>
         bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
     }
+    */
 
     /// <summary>
     /// Interface marking a validation component that validates specific untyped properties.

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
-using ReactiveUI.Validation.Extensions;
 
 namespace ReactiveUI.Validation.Components.Abstractions
 {
@@ -27,6 +26,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
         /// <param name="propertyExpression">ViewModel property.</param>
         /// <param name="exclusively">Indicates if the property to find is unique.</param>
         /// <returns>Returns true if it contains the property, otherwise false.</returns>
+        [ExcludeFromCodeCoverage]
         [Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
         bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
     }

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
@@ -7,14 +7,15 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
+using ReactiveUI.Validation.Extensions;
 
 namespace ReactiveUI.Validation.Components.Abstractions
 {
-    /*
     /// <summary>
     /// Interface marking a validation component that validates specific typed properties.
     /// </summary>
     /// <typeparam name="TViewModel">The validation target.</typeparam>
+    [Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:FileHeaderFileNameDocumentationMustMatchTypeName", Justification = "Same type just generic.")]
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same type just generic.")]
     public interface IValidatesProperties<TViewModel> : IValidatesProperties
@@ -26,9 +27,9 @@ namespace ReactiveUI.Validation.Components.Abstractions
         /// <param name="propertyExpression">ViewModel property.</param>
         /// <param name="exclusively">Indicates if the property to find is unique.</param>
         /// <returns>Returns true if it contains the property, otherwise false.</returns>
+        [Obsolete("Consider using the non-generic version of an IValidatesProperties.")]
         bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> propertyExpression, bool exclusively = false);
     }
-    */
 
     /// <summary>
     /// Interface marking a validation component that validates specific untyped properties.

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -22,11 +22,10 @@ namespace ReactiveUI.Validation.Components
 {
     /// <inheritdoc cref="ReactiveObject" />
     /// <inheritdoc cref="IDisposable" />
-    /// <inheritdoc cref="IPropertyValidationComponent{TViewModel}" />
     /// <summary>
     /// Base class for items which are used to build a <see cref="ReactiveUI.Validation.Contexts.ValidationContext" />.
     /// </summary>
-    public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent<TViewModel>
+    public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent
     {
         [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
         private readonly ReplaySubject<bool> _isValidSubject = new ReplaySubject<bool>(1);

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -100,6 +100,7 @@ namespace ReactiveUI.Validation.Components
         }
 
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         [Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidationComponent.")]
         public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
         {

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -25,7 +25,7 @@ namespace ReactiveUI.Validation.Components
     /// <summary>
     /// Base class for items which are used to build a <see cref="ReactiveUI.Validation.Contexts.ValidationContext" />.
     /// </summary>
-    public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent
+    public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent, IPropertyValidationComponent<TViewModel>
     {
         [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
         private readonly ReplaySubject<bool> _isValidSubject = new ReplaySubject<bool>(1);
@@ -100,6 +100,7 @@ namespace ReactiveUI.Validation.Components
         }
 
         /// <inheritdoc/>
+        [Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidationComponent.")]
         public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
         {
             if (property is null)

--- a/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
@@ -190,7 +190,7 @@ namespace ReactiveUI.Validation.Components
     [ExcludeFromCodeCoverage]
     [Obsolete("Consider using ObservableValidation<TViewModel, bool> instead.")]
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just an abstract one.")]
-    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent
+    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent, IPropertyValidationComponent<TViewModel>
     {
         [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
         private readonly ReplaySubject<ValidationState> _lastValidationStateSubject = new ReplaySubject<ValidationState>(1);
@@ -274,6 +274,7 @@ namespace ReactiveUI.Validation.Components
         }
 
         /// <inheritdoc/>
+        [Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidationComponent.")]
         public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
         {
             if (property is null)

--- a/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
@@ -274,6 +274,7 @@ namespace ReactiveUI.Validation.Components
         }
 
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         [Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidationComponent.")]
         public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
         {

--- a/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
@@ -178,7 +178,6 @@ namespace ReactiveUI.Validation.Components
     }
 
     /// <inheritdoc cref="ReactiveObject" />
-    /// <inheritdoc cref="IPropertyValidationComponent{TViewModel}" />
     /// <inheritdoc cref="IDisposable" />
     /// <summary>
     /// More generic observable for determination of validity.
@@ -191,7 +190,7 @@ namespace ReactiveUI.Validation.Components
     [ExcludeFromCodeCoverage]
     [Obsolete("Consider using ObservableValidation<TViewModel, bool> instead.")]
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just an abstract one.")]
-    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent<TViewModel>
+    public abstract class ModelObservableValidationBase<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent
     {
         [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
         private readonly ReplaySubject<ValidationState> _lastValidationStateSubject = new ReplaySubject<ValidationState>(1);

--- a/src/ReactiveUI.Validation/Components/ObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation.cs
@@ -247,13 +247,12 @@ namespace ReactiveUI.Validation.Components
     }
 
     /// <inheritdoc cref="ReactiveObject" />
-    /// <inheritdoc cref="IPropertyValidationComponent{TViewModel}" />
     /// <inheritdoc cref="IDisposable" />
     /// <summary>
     /// A validation component that is based on an <see cref="IObservable{T}"/>.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObject, IDisposable, IPropertyValidationComponent<TViewModel>
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObject, IDisposable, IPropertyValidationComponent
     {
         [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
         private readonly ReplaySubject<ValidationState> _isValidSubject = new ReplaySubject<ValidationState>(1);

--- a/src/ReactiveUI.Validation/Components/ObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation.cs
@@ -343,6 +343,7 @@ namespace ReactiveUI.Validation.Components
         }
 
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
         [Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidationComponent.")]
         public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
         {

--- a/src/ReactiveUI.Validation/Components/ObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation.cs
@@ -19,7 +19,6 @@ using ReactiveUI.Validation.States;
 namespace ReactiveUI.Validation.Components
 {
     /// <inheritdoc cref="ReactiveObject" />
-    /// <inheritdoc cref="IPropertyValidationComponent{TViewModel}" />
     /// <inheritdoc cref="IDisposable" />
     /// <summary>
     /// A validation component that is based on an <see cref="IObservable{T}"/>. Validates a single property.
@@ -139,7 +138,6 @@ namespace ReactiveUI.Validation.Components
     }
 
     /// <inheritdoc cref="ReactiveObject" />
-    /// <inheritdoc cref="IPropertyValidationComponent{TViewModel}" />
     /// <inheritdoc cref="IDisposable" />
     /// <summary>
     /// A validation component that is based on an <see cref="IObservable{T}"/>.
@@ -252,7 +250,7 @@ namespace ReactiveUI.Validation.Components
     /// A validation component that is based on an <see cref="IObservable{T}"/>.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObject, IDisposable, IPropertyValidationComponent
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObject, IDisposable, IPropertyValidationComponent, IPropertyValidationComponent<TViewModel>
     {
         [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
         private readonly ReplaySubject<ValidationState> _isValidSubject = new ReplaySubject<ValidationState>(1);
@@ -345,6 +343,7 @@ namespace ReactiveUI.Validation.Components
         }
 
         /// <inheritdoc/>
+        [Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidationComponent.")]
         public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
         {
             if (property is null)

--- a/src/ReactiveUI.Validation/Extensions/ValidatesPropertiesExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatesPropertiesExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq.Expressions;
+using ReactiveUI.Validation.Components.Abstractions;
+
+namespace ReactiveUI.Validation.Extensions
+{
+    /// <summary>
+    /// Extensions for <see cref="IValidatesProperties"/>.
+    /// </summary>
+    public static class ValidatesPropertiesExtensions
+    {
+        /// <summary>
+        /// Determine if a property name is actually contained within this.
+        /// </summary>
+        /// <typeparam name="TViewModel">View model type.</typeparam>
+        /// <typeparam name="TProp">View model property type.</typeparam>
+        /// <param name="validatesProperties">The validation component.</param>
+        /// <param name="propertyExpression">ViewModel property.</param>
+        /// <param name="exclusively">Indicates if the property to find is unique.</param>
+        /// <returns>Returns true if it contains the property, otherwise false.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+        public static bool ContainsProperty<TViewModel, TProp>(
+            this IValidatesProperties validatesProperties,
+            Expression<Func<TViewModel, TProp>> propertyExpression,
+            bool exclusively = false)
+        {
+            if (validatesProperties == null)
+            {
+                throw new ArgumentNullException(nameof(validatesProperties));
+            }
+
+            if (propertyExpression is null)
+            {
+                throw new ArgumentNullException(nameof(propertyExpression));
+            }
+
+            var propertyName = propertyExpression.Body.GetPropertyPath();
+            return validatesProperties.ContainsPropertyName(propertyName, exclusively);
+        }
+    }
+}

--- a/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
@@ -73,7 +73,7 @@ namespace ReactiveUI.Validation.Extensions
         [ExcludeFromCodeCoverage]
         [Obsolete("Since we support adding and removing validation rules dynamically, consider " +
                   "using either the ObserveFor extension method, or BindValidation.")]
-        public static IEnumerable<IPropertyValidationComponent> ResolveFor<TViewModel, TViewModelProperty>(
+        public static IEnumerable<IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TViewModelProperty>(
             this ValidationContext context,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             bool strict = true)
@@ -90,7 +90,7 @@ namespace ReactiveUI.Validation.Extensions
 
             return context
                 .Validations
-                .OfType<IPropertyValidationComponent>()
+                .OfType<IPropertyValidationComponent<TViewModel>>()
                 .Where(v => v.ContainsProperty(viewModelProperty, strict));
         }
 
@@ -107,7 +107,7 @@ namespace ReactiveUI.Validation.Extensions
         [ExcludeFromCodeCoverage]
         [Obsolete("Since we support adding and removing validation rules dynamically, consider " +
                   "using either the ObserveFor extension method, or BindValidation.")]
-        public static IEnumerable<IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1,
+        public static IEnumerable<IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1,
             TProperty2>(
             this ValidationContext context,
             Expression<Func<TViewModel, TProperty1>> viewModelProperty1,
@@ -130,7 +130,7 @@ namespace ReactiveUI.Validation.Extensions
 
             return context
                 .Validations
-                .OfType<IPropertyValidationComponent>()
+                .OfType<IPropertyValidationComponent<TViewModel>>()
                 .Where(v => v.ContainsProperty(viewModelProperty1) &&
                             v.ContainsProperty(viewModelProperty2) &&
                             v.PropertyCount == 2);
@@ -151,7 +151,7 @@ namespace ReactiveUI.Validation.Extensions
         [ExcludeFromCodeCoverage]
         [Obsolete("Since we support adding and removing validation rules dynamically, consider " +
                   "using either the ObserveFor extension method, or BindValidation.")]
-        public static IEnumerable<IPropertyValidationComponent> ResolveFor<TViewModel,
+        public static IEnumerable<IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel,
             TProperty1, TProperty2, TProperty3>(
             this ValidationContext context,
             Expression<Func<TViewModel, TProperty1>> viewModelProperty1,
@@ -180,7 +180,7 @@ namespace ReactiveUI.Validation.Extensions
 
             return context
                 .Validations
-                .OfType<IPropertyValidationComponent>()
+                .OfType<IPropertyValidationComponent<TViewModel>>()
                 .Where(v => v.ContainsProperty(viewModelProperty1) &&
                             v.ContainsProperty(viewModelProperty2) &&
                             v.ContainsProperty(viewModelProperty3) &&

--- a/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
@@ -53,7 +53,7 @@ namespace ReactiveUI.Validation.Extensions
                 .ToObservableChangeSet()
                 .ToCollection()
                 .Select(validations => validations
-                    .OfType<IPropertyValidationComponent<TViewModel>>()
+                    .OfType<IPropertyValidationComponent>()
                     .Where(validation => validation.ContainsProperty(viewModelProperty, strict))
                     .Select(validation => validation.ValidationStatusChange)
                     .CombineLatest()
@@ -73,7 +73,7 @@ namespace ReactiveUI.Validation.Extensions
         [ExcludeFromCodeCoverage]
         [Obsolete("Since we support adding and removing validation rules dynamically, consider " +
                   "using either the ObserveFor extension method, or BindValidation.")]
-        public static IEnumerable<IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TViewModelProperty>(
+        public static IEnumerable<IPropertyValidationComponent> ResolveFor<TViewModel, TViewModelProperty>(
             this ValidationContext context,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             bool strict = true)
@@ -90,7 +90,7 @@ namespace ReactiveUI.Validation.Extensions
 
             return context
                 .Validations
-                .OfType<IPropertyValidationComponent<TViewModel>>()
+                .OfType<IPropertyValidationComponent>()
                 .Where(v => v.ContainsProperty(viewModelProperty, strict));
         }
 
@@ -107,7 +107,7 @@ namespace ReactiveUI.Validation.Extensions
         [ExcludeFromCodeCoverage]
         [Obsolete("Since we support adding and removing validation rules dynamically, consider " +
                   "using either the ObserveFor extension method, or BindValidation.")]
-        public static IEnumerable<IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel, TProperty1,
+        public static IEnumerable<IPropertyValidationComponent> ResolveFor<TViewModel, TProperty1,
             TProperty2>(
             this ValidationContext context,
             Expression<Func<TViewModel, TProperty1>> viewModelProperty1,
@@ -130,7 +130,7 @@ namespace ReactiveUI.Validation.Extensions
 
             return context
                 .Validations
-                .OfType<IPropertyValidationComponent<TViewModel>>()
+                .OfType<IPropertyValidationComponent>()
                 .Where(v => v.ContainsProperty(viewModelProperty1) &&
                             v.ContainsProperty(viewModelProperty2) &&
                             v.PropertyCount == 2);
@@ -151,7 +151,7 @@ namespace ReactiveUI.Validation.Extensions
         [ExcludeFromCodeCoverage]
         [Obsolete("Since we support adding and removing validation rules dynamically, consider " +
                   "using either the ObserveFor extension method, or BindValidation.")]
-        public static IEnumerable<IPropertyValidationComponent<TViewModel>> ResolveFor<TViewModel,
+        public static IEnumerable<IPropertyValidationComponent> ResolveFor<TViewModel,
             TProperty1, TProperty2, TProperty3>(
             this ValidationContext context,
             Expression<Func<TViewModel, TProperty1>> viewModelProperty1,
@@ -180,7 +180,7 @@ namespace ReactiveUI.Validation.Extensions
 
             return context
                 .Validations
-                .OfType<IPropertyValidationComponent<TViewModel>>()
+                .OfType<IPropertyValidationComponent>()
                 .Where(v => v.ContainsProperty(viewModelProperty1) &&
                             v.ContainsProperty(viewModelProperty2) &&
                             v.ContainsProperty(viewModelProperty3) &&


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR deprecates the generic `IPropertyValidationComponent<TViewModel>` and `IValidatesProperties<TViewModel>` in favor of the non-generic version of these interfaces, namely `IPropertyValidationComponent` and `IValidatesProperties`. The reasoning for this change was described in detail by @thargy in https://github.com/reactiveui/ReactiveUI.Validation/pull/118#issuecomment-708322698

> Commit 1565d37, updated `IValidatesProperties`, splitting it into generic/non-generic versions.  The generic version now contains solely the problematic <...> I say problematic, as implementing such an interface is non-trivial for authors intending to extend validation rules outside the library. The current implementation within the library is always the same <...> and makes use of the GetPropertyPath extension method, which is marked internal, necessitating consumers rewrite a version of that method.

Now, the generic `ContainsProperty` method is extracted into a separate class named `ValidatesPropertiesExtensions`.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, if folks decide to implement the generic versions of the mentioned interfaces, namely  `IPropertyValidationComponent<TViewModel>` and `IValidatesProperties<TViewModel>`, they experience difficulties, and the implementation of these two interfaces is always the same.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, the interfaces are deprecated in favor of their non-generic versions. This should simplify extending ReactiveUI.Validation.

**What might this PR break?**

Hopefully, nothing, as we aren't removing the interfaces, but just deprecating them by marking as `[Obsolete]`.
