### PR TITLE
feature: Add ClearValidationRules Extension Methods

### DIFF
--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -167,12 +167,17 @@ namespace ReactiveUI.Validation.Contexts
         protected virtual void Dispose(bool disposing) { }
         public bool GetIsValid() { }
         public void Remove(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
+        public void RemoveMany(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> validations) { }
     }
 }
 namespace ReactiveUI.Validation.Extensions
 {
     public static class ValidatableViewModelExtensions
     {
+        public static void ClearValidationRules<TViewModel>(this TViewModel viewModel)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static void ClearValidationRules<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -167,12 +167,17 @@ namespace ReactiveUI.Validation.Contexts
         protected virtual void Dispose(bool disposing) { }
         public bool GetIsValid() { }
         public void Remove(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
+        public void RemoveMany(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> validations) { }
     }
 }
 namespace ReactiveUI.Validation.Extensions
 {
     public static class ValidatableViewModelExtensions
     {
+        public static void ClearValidationRules<TViewModel>(this TViewModel viewModel)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static void ClearValidationRules<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
@@ -137,6 +137,7 @@ namespace ReactiveUI.Validation.Tests
 
         /// <summary>
         /// Ensures that the ClearValidationRules extension method works.
+        /// Also verifies that the ClearValidationRules extension method is idempotent.
         /// </summary>
         [Fact]
         public void ShouldClearAttachedValidationRules()
@@ -156,11 +157,19 @@ namespace ReactiveUI.Validation.Tests
 
             viewModel.ValidationContext.Add(nameValidation);
             viewModel.ValidationContext.Add(name2Validation);
+
             Assert.Equal(2, viewModel.ValidationContext.Validations.Count);
             Assert.False(viewModel.ValidationContext.IsValid);
             Assert.NotEmpty(viewModel.ValidationContext.Text);
 
             viewModel.ClearValidationRules();
+
+            Assert.Equal(0, viewModel.ValidationContext.Validations.Count);
+            Assert.True(viewModel.ValidationContext.IsValid);
+            Assert.Empty(viewModel.ValidationContext.Text);
+
+            viewModel.ClearValidationRules();
+
             Assert.Equal(0, viewModel.ValidationContext.Validations.Count);
             Assert.True(viewModel.ValidationContext.IsValid);
             Assert.Empty(viewModel.ValidationContext.Text);
@@ -168,6 +177,7 @@ namespace ReactiveUI.Validation.Tests
 
         /// <summary>
         /// Ensures that the ClearValidationRules extension method accepting an expression works.
+        /// Also verifies that the ClearValidationRules extension method is idempotent.
         /// </summary>
         [Fact]
         public void ShouldClearAttachedValidationRulesForTheGivenProperty()
@@ -188,11 +198,21 @@ namespace ReactiveUI.Validation.Tests
 
             viewModel.ValidationContext.Add(nameValidation);
             viewModel.ValidationContext.Add(name2Validation);
+
             Assert.Equal(2, viewModel.ValidationContext.Validations.Count);
             Assert.False(viewModel.ValidationContext.IsValid);
             Assert.NotEmpty(viewModel.ValidationContext.Text);
+            Assert.Throws<ArgumentNullException>(() => viewModel.ClearValidationRules<TestViewModel, string>(null!));
 
             viewModel.ClearValidationRules(x => x.Name);
+
+            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.False(viewModel.ValidationContext.IsValid);
+            Assert.NotEmpty(viewModel.ValidationContext.Text);
+            Assert.Equal(name2ErrorMessage, viewModel.ValidationContext.Text.ToSingleLine());
+
+            viewModel.ClearValidationRules(x => x.Name);
+
             Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
             Assert.False(viewModel.ValidationContext.IsValid);
             Assert.NotEmpty(viewModel.ValidationContext.Text);

--- a/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
@@ -168,6 +168,7 @@ namespace ReactiveUI.Validation.Tests
             Assert.True(viewModel.ValidationContext.IsValid);
             Assert.Empty(viewModel.ValidationContext.Text);
 
+            // Verify that the method is idempotent.
             viewModel.ClearValidationRules();
 
             Assert.Equal(0, viewModel.ValidationContext.Validations.Count);
@@ -211,6 +212,7 @@ namespace ReactiveUI.Validation.Tests
             Assert.NotEmpty(viewModel.ValidationContext.Text);
             Assert.Equal(name2ErrorMessage, viewModel.ValidationContext.Text.ToSingleLine());
 
+            // Verify that the method is idempotent.
             viewModel.ClearValidationRules(x => x.Name);
 
             Assert.Equal(1, viewModel.ValidationContext.Validations.Count);

--- a/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
@@ -165,5 +165,38 @@ namespace ReactiveUI.Validation.Tests
             Assert.True(viewModel.ValidationContext.IsValid);
             Assert.Empty(viewModel.ValidationContext.Text);
         }
+
+        /// <summary>
+        /// Ensures that the ClearValidationRules extension method accepting an expression works.
+        /// </summary>
+        [Fact]
+        public void ShouldClearAttachedValidationRulesForTheGivenProperty()
+        {
+            var viewModel = new TestViewModel { Name = string.Empty };
+            var nameValidation = new BasePropertyValidation<TestViewModel, string>(
+                viewModel,
+                viewModelProperty => viewModelProperty.Name,
+                s => !string.IsNullOrEmpty(s),
+                "Name should not be empty.");
+
+            const string name2ErrorMessage = "Name2 should not be empty.";
+            var name2Validation = new BasePropertyValidation<TestViewModel, string>(
+                viewModel,
+                viewModelProperty => viewModelProperty.Name2,
+                s => !string.IsNullOrEmpty(s),
+                name2ErrorMessage);
+
+            viewModel.ValidationContext.Add(nameValidation);
+            viewModel.ValidationContext.Add(name2Validation);
+            Assert.Equal(2, viewModel.ValidationContext.Validations.Count);
+            Assert.False(viewModel.ValidationContext.IsValid);
+            Assert.NotEmpty(viewModel.ValidationContext.Text);
+
+            viewModel.ClearValidationRules(x => x.Name);
+            Assert.Equal(1, viewModel.ValidationContext.Validations.Count);
+            Assert.False(viewModel.ValidationContext.IsValid);
+            Assert.NotEmpty(viewModel.ValidationContext.Text);
+            Assert.Equal(name2ErrorMessage, viewModel.ValidationContext.Text.ToSingleLine());
+        }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationContextTests.cs
@@ -134,5 +134,36 @@ namespace ReactiveUI.Validation.Tests
             viewModel.Name = string.Empty;
             Assert.False(latestValidity);
         }
+
+        /// <summary>
+        /// Ensures that the ClearValidationRules extension method works.
+        /// </summary>
+        [Fact]
+        public void ShouldClearAttachedValidationRules()
+        {
+            var viewModel = new TestViewModel { Name = string.Empty };
+            var nameValidation = new BasePropertyValidation<TestViewModel, string>(
+                viewModel,
+                viewModelProperty => viewModelProperty.Name,
+                s => !string.IsNullOrEmpty(s),
+                "Name should not be empty.");
+
+            var name2Validation = new BasePropertyValidation<TestViewModel, string>(
+                viewModel,
+                viewModelProperty => viewModelProperty.Name2,
+                s => !string.IsNullOrEmpty(s),
+                "Name2 should not be empty.");
+
+            viewModel.ValidationContext.Add(nameValidation);
+            viewModel.ValidationContext.Add(name2Validation);
+            Assert.Equal(2, viewModel.ValidationContext.Validations.Count);
+            Assert.False(viewModel.ValidationContext.IsValid);
+            Assert.NotEmpty(viewModel.ValidationContext.Text);
+
+            viewModel.ClearValidationRules();
+            Assert.Equal(0, viewModel.ValidationContext.Validations.Count);
+            Assert.True(viewModel.ValidationContext.IsValid);
+            Assert.Empty(viewModel.ValidationContext.Text);
+        }
     }
 }

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -159,6 +159,21 @@ namespace ReactiveUI.Validation.Contexts
         });
 
         /// <summary>
+        /// Removes many validation components from the validations collection.
+        /// </summary>
+        /// <param name="validations">Validation components to be removed from the collection.</param>
+        public void RemoveMany(IEnumerable<IValidationComponent> validations) => _validationSource.Edit(list =>
+        {
+            foreach (var validation in validations)
+            {
+                if (list.Contains(validation))
+                {
+                    list.Remove(validation);
+                }
+            }
+        });
+
+        /// <summary>
         /// Returns if the whole context is valid checking all the validations.
         /// </summary>
         /// <returns>Returns true if the <see cref="ValidationContext"/> is valid, otherwise false.</returns>

--- a/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reactive.Disposables;
 using ReactiveUI.Validation.Abstractions;
@@ -298,6 +299,58 @@ namespace ReactiveUI.Validation.Extensions
             return viewModel.RegisterValidation(
                 new ObservableValidation<TViewModel, TValue, TViewModelProp>(
                     viewModel, viewModelProperty, viewModelObservable, isValidFunc, messageFunc));
+        }
+
+        /// <summary>
+        /// Clears the validation rules associated with teh specified property.
+        /// </summary>
+        /// <param name="viewModel">The view model to remove the validation rule from.</param>
+        /// <param name="viewModelProperty">The property for which we are clearing the validation rules.</param>
+        /// <typeparam name="TViewModel">ViewModel type.</typeparam>
+        /// <typeparam name="TViewModelProp">ViewModel property type.</typeparam>
+        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+        public static void ClearValidationRules<TViewModel, TViewModelProp>(
+            this TViewModel viewModel,
+            Expression<Func<TViewModel, TViewModelProp>> viewModelProperty)
+            where TViewModel : IReactiveObject, IValidatableViewModel
+        {
+            if (viewModel is null)
+            {
+                throw new ArgumentNullException(nameof(viewModel));
+            }
+
+            if (viewModelProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewModelProperty));
+            }
+
+            var validationComponents = viewModel
+                .ValidationContext
+                .Validations
+                .OfType<IPropertyValidationComponent>()
+                .Where(validation => validation.ContainsProperty(viewModelProperty))
+                .ToList();
+
+            viewModel
+                .ValidationContext
+                .RemoveMany(validationComponents);
+        }
+
+        /// <summary>
+        /// Removes all validation rules associated with a view model.
+        /// </summary>
+        /// <param name="viewModel">The view model to remove all validation rules from.</param>
+        /// <typeparam name="TViewModel">ViewModel type.</typeparam>
+        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+        public static void ClearValidationRules<TViewModel>(this TViewModel viewModel)
+            where TViewModel : IReactiveObject, IValidatableViewModel
+        {
+            if (viewModel is null)
+            {
+                throw new ArgumentNullException(nameof(viewModel));
+            }
+
+            viewModel.ValidationContext.RemoveMany(viewModel.ValidationContext.Validations);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR implements a feature described in https://github.com/reactiveui/ReactiveUI.Validation/issues/71

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, there is no `ClearValidationRule` extension method.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, there are two `ClearValidationRule` extension methods, one of them removes all validations from a context, and another one accepts a property expression selector and removes only those validations that reference the specified property.

**What might this PR break?**

Nothing.

**Other information**:

Fixes  https://github.com/reactiveui/ReactiveUI.Validation/issues/71