### PR TITLE
feature: Use IValidationState Instead of ValidationState

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ IObservable<IValidationState> usernameNotEmpty =
     this.WhenAnyValue(x => x.UserName)
         .Select(name => string.IsNullOrEmpty(name) 
             ? new ValidationState(false, "The username must not be empty")
-            : new ValidationState(true, string.Empty));
+            : ValidationState.Valid);
 
 this.ValidationRule(vm => vm.UserName, usernameNotEmpty);
 ```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ this.ValidationRule(
     state => $"Passwords must match: {state.Password} != {state.Confirmation}");
 ```
 
+Finally, you can directly supply any state that implements `IValidationState`; or you can use the `ValidationState` base class which already implements the interface.  As the resulting object is stored directly against the context without further transformation, this can be the most performant approach:
+```csharp
+IObservable<IValidationState> usernameNotEmpty =
+    this.WhenAnyValue(x => x.UserName)
+        .Select(name => string.IsNullOrEmpty(name) 
+            ? new ValidationState(false, "The username must not be empty")
+            : new ValidationState(true, string.Empty));
+
+this.ValidationRule(vm => vm.UserName, usernameNotEmpty);
+```
+
 2. Add validation presentation to the View.
 
 ```csharp
@@ -174,7 +185,7 @@ public class SampleViewModel : ReactiveValidationObject
 }
 ```
 
-When using the `ValidationRule` overload that uses `IObservable<bool>` for more complex scenarios please keep in mind to supply the property which the validation rule is targeting as the first argument. Otherwise it is not possible for `INotifyDataErrorInfo` to conclude which property the error message is for.
+When using the `ValidationRule` overload that uses `IObservable<bool>` for more complex scenarios please remember to supply the property which the validation rule is targeting as the first argument. Otherwise it is not possible for `INotifyDataErrorInfo` to conclude which property the error message is for.
 
 ```csharp
 this.ValidationRule(

--- a/samples/LoginApp/ViewModels/SignUpViewModel.cs
+++ b/samples/LoginApp/ViewModels/SignUpViewModel.cs
@@ -81,21 +81,19 @@ namespace LoginApp.ViewModels
             // emits an empty string when UserName is valid, and emits a non-empty when UserName
             // is either invalid, or just changed and hasn't been validated yet.
 
-            IObservable<ValidationState> usernameValidated =
+            IObservable<IValidationState> usernameValidated =
                 this.WhenAnyValue(x => x.UserName)
                     .Throttle(TimeSpan.FromSeconds(0.7), RxApp.TaskpoolScheduler)
                     .SelectMany(ValidateNameImpl)
                     .ObserveOn(RxApp.MainThreadScheduler);
 
-            IObservable<ValidationState> usernameDirty =
+            IObservable<IValidationState> usernameDirty =
                 this.WhenAnyValue(x => x.UserName)
                     .Select(name => new ValidationState(false, "Please wait..."));
 
             this.ValidationRule(
                 vm => vm.UserName,
-                usernameValidated.Merge(usernameDirty),
-                state => state.IsValid,
-                state => $"Server says: {state.Text.ToSingleLine()}");
+                usernameValidated.Merge(usernameDirty));
 
             _isBusy = usernameValidated
                 .Select(message => false)
@@ -148,7 +146,7 @@ namespace LoginApp.ViewModels
 
         private void SignUpImpl() => _dialogs.ShowDialog("User created successfully.");
 
-        private static async Task<ValidationState> ValidateNameImpl(string username)
+        private static async Task<IValidationState> ValidateNameImpl(string username)
         {
             await Task.Delay(TimeSpan.FromSeconds(0.5));
             return username.Length < 2

--- a/samples/LoginApp/ViewModels/SignUpViewModel.cs
+++ b/samples/LoginApp/ViewModels/SignUpViewModel.cs
@@ -153,7 +153,7 @@ namespace LoginApp.ViewModels
                 ? new ValidationState(false, "The name is too short.")
                 : username.Any(letter => !char.IsLetter(letter))
                     ? new ValidationState(false, "Only letters allowed.")
-                    : new ValidationState(true, string.Empty);
+                    : ValidationState.Valid;
         }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -118,10 +118,23 @@ namespace ReactiveUI.Validation.Components
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, string message) { }
     }
+    public class ObservableValidation : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    {
+        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        public bool IsValid { get; }
+        public System.Collections.Generic.IEnumerable<string> Properties { get; }
+        public int PropertyCount { get; }
+        public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
+        public void AddProperty(System.Linq.Expressions.LambdaExpression propertyExpression) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+    }
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
         "lidation<TViewModel> as a base class.")]
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent
     {
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
@@ -132,20 +145,7 @@ namespace ReactiveUI.Validation.Components
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
     }
-    public class ObservableValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
-    {
-        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
-        public bool IsValid { get; }
-        public System.Collections.Generic.IEnumerable<string> Properties { get; }
-        public int PropertyCount { get; }
-        public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
-        public void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
-        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
-        public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-    }
-    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>
+    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation
     {
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -153,7 +153,7 @@ namespace ReactiveUI.Validation.Components
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidation
     {
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -23,11 +23,11 @@ namespace ReactiveUI.Validation.Collections
 }
 namespace ReactiveUI.Validation.Comparators
 {
-    public class ValidationStateComparer : System.Collections.Generic.EqualityComparer<ReactiveUI.Validation.States.ValidationState>
+    public class ValidationStateComparer : System.Collections.Generic.EqualityComparer<ReactiveUI.Validation.States.IValidationState>
     {
         public ValidationStateComparer() { }
-        public override bool Equals(ReactiveUI.Validation.States.ValidationState x, ReactiveUI.Validation.States.ValidationState y) { }
-        public override int GetHashCode(ReactiveUI.Validation.States.ValidationState obj) { }
+        public override bool Equals(ReactiveUI.Validation.States.IValidationState x, ReactiveUI.Validation.States.IValidationState y) { }
+        public override int GetHashCode(ReactiveUI.Validation.States.IValidationState obj) { }
     }
 }
 namespace ReactiveUI.Validation.Components.Abstractions
@@ -52,7 +52,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
     {
         bool IsValid { get; }
         ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
     }
 }
 namespace ReactiveUI.Validation.Components
@@ -64,7 +64,7 @@ namespace ReactiveUI.Validation.Components
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
@@ -73,7 +73,7 @@ namespace ReactiveUI.Validation.Components
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        protected abstract System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable();
+        protected abstract System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable();
     }
     public sealed class BasePropertyValidation<TViewModel, TViewModelProperty> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -81,7 +81,7 @@ namespace ReactiveUI.Validation.Components
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Func<TViewModelProperty, bool> isValidFunc, System.Func<TViewModelProperty, bool, string> messageFunc) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Func<TViewModelProperty, bool> isValidFunc, string message) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [System.Obsolete("Consider using ObservableValidation<TViewModel, bool> instead.")]
@@ -92,7 +92,7 @@ namespace ReactiveUI.Validation.Components
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
@@ -118,14 +118,14 @@ namespace ReactiveUI.Validation.Components
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, string message) { }
     }
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public class ObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
-        protected ObservableValidationBase(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
+        public ObservableValidationBase(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
         public bool IsValid { get; }
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
@@ -135,7 +135,7 @@ namespace ReactiveUI.Validation.Components
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
+    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel>
     {
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -143,7 +143,7 @@ namespace ReactiveUI.Validation.Components
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel>
     {
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -160,7 +160,7 @@ namespace ReactiveUI.Validation.Contexts
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.ValidationText Text { get; }
         public System.IObservable<bool> Valid { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         public System.Collections.ObjectModel.ReadOnlyObservableCollection<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }
         public void Add(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
         public void Dispose() { }
@@ -231,7 +231,7 @@ namespace ReactiveUI.Validation.Extensions
     }
     public static class ValidationContextExtensions
     {
-        public static System.IObservable<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>> ObserveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
+        public static System.IObservable<System.Collections.Generic.IList<ReactiveUI.Validation.States.IValidationState>> ObserveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
@@ -307,18 +307,29 @@ namespace ReactiveUI.Validation.Helpers
         public ValidationHelper(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation, System.IDisposable? cleanup = null) { }
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Message { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationChanged { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationChanged { get; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }
 }
 namespace ReactiveUI.Validation.States
 {
-    public sealed class ValidationState
+    public interface IValidationState
     {
+        bool IsValid { get; }
+        ReactiveUI.Validation.Collections.ValidationText Text { get; }
+    }
+    public class ValidationState : ReactiveUI.Validation.States.IValidationState
+    {
+        public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text) { }
+        public ValidationState(bool isValid, string text) { }
+        [System.Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text, ReactiveUI.Validation.Components.Abstractions.IValidationComponent component) { }
+        [System.Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, string text, ReactiveUI.Validation.Components.Abstractions.IValidationComponent component) { }
-        public ReactiveUI.Validation.Components.Abstractions.IValidationComponent Component { get; }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        [System.Obsolete("This property will be removed soon.")]
+        public ReactiveUI.Validation.Components.Abstractions.IValidationComponent? Component { get; }
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.ValidationText Text { get; }
     }
@@ -331,7 +342,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Func<System.ValueTuple<TProperty1, TProperty2>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Func<System.ValueTuple<TProperty1, TProperty2>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     public sealed class BasePropertyValidation<TViewModel, TProperty1, TProperty2, TProperty3> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -339,7 +350,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     public sealed class BasePropertyValidation<TViewModel, TProperty1, TProperty2, TProperty3, TProperty4> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -347,7 +358,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     public sealed class BasePropertyValidation<TViewModel, TProperty1, TProperty2, TProperty3, TProperty4, TProperty5> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -355,7 +366,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty5>> property5, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty5>> property5, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     public sealed class BasePropertyValidation<TViewModel, TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -363,7 +374,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty5>> property5, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty6>> property6, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty5>> property5, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty6>> property6, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
 }
 namespace ReactiveUI.Validation.ValidationBindings.Abstractions
@@ -375,13 +386,13 @@ namespace ReactiveUI.Validation.ValidationBindings
     public sealed class ValidationBinding : ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding, System.IDisposable
     {
         public void Dispose() { }
-        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>, System.Collections.Generic.IList<TOut>> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter, bool strict = true)
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<System.Collections.Generic.IList<ReactiveUI.Validation.States.IValidationState>, System.Collections.Generic.IList<TOut>> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter, bool strict = true)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null, bool strict = true)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
-        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Action<ReactiveUI.Validation.States.ValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Action<ReactiveUI.Validation.States.IValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -118,43 +118,36 @@ namespace ReactiveUI.Validation.Components
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, string message) { }
     }
-    public class ObservableValidation : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
-        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        protected ObservableValidationBase(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        protected ObservableValidationBase(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
         public bool IsValid { get; }
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
-        public void AddProperty(System.Linq.Expressions.LambdaExpression propertyExpression) { }
-        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
-        public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-    }
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
-        "lidation<TViewModel> as a base class.")]
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent
-    {
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
-            "lidation<TViewModel> as a base class.")]
-        protected ObservableValidationBase(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
+        protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation
+    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
     {
+        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidation
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
     {
+        public ObservableValidation(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, string> messageFunc) { }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -335,6 +335,7 @@ namespace ReactiveUI.Validation.States
     }
     public class ValidationState : ReactiveUI.Validation.States.IValidationState
     {
+        public static readonly ReactiveUI.Validation.States.ValidationState Valid;
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text) { }
         public ValidationState(bool isValid, string text) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -118,24 +118,34 @@ namespace ReactiveUI.Validation.Components
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, string message) { }
     }
-    public class ObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
+        "lidation<TViewModel> as a base class.")]
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent
     {
-        public ObservableValidationBase(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
+            "lidation<TViewModel> as a base class.")]
+        protected ObservableValidationBase(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
+            "ionComponent.")]
+        public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
+    }
+    public class ObservableValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    {
+        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
         public bool IsValid { get; }
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
-        protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
-            "ionComponent.")]
-        public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
+        public void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel>
+    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>
     {
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -143,7 +153,7 @@ namespace ReactiveUI.Validation.Components
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel>
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>
     {
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -180,6 +190,8 @@ namespace ReactiveUI.Validation.Extensions
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.IObservable<ReactiveUI.Validation.States.IValidationState> validationObservable)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Use the overload accepting just IObservable<bool> instead of Func<TViewModel, IOb" +
             "servable<bool>>")]
@@ -197,6 +209,8 @@ namespace ReactiveUI.Validation.Extensions
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, string message)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.IObservable<bool> validationObservable, string message)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.IObservable<ReactiveUI.Validation.States.IValidationState> validationObservable)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TValue>(this TViewModel viewModel, System.IObservable<TValue> validationObservable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
@@ -323,8 +337,10 @@ namespace ReactiveUI.Validation.States
     {
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text) { }
         public ValidationState(bool isValid, string text) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text, ReactiveUI.Validation.Components.Abstractions.IValidationComponent component) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, string text, ReactiveUI.Validation.Components.Abstractions.IValidationComponent component) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -118,10 +118,23 @@ namespace ReactiveUI.Validation.Components
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, string message) { }
     }
+    public class ObservableValidation : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    {
+        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        public bool IsValid { get; }
+        public System.Collections.Generic.IEnumerable<string> Properties { get; }
+        public int PropertyCount { get; }
+        public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
+        public void AddProperty(System.Linq.Expressions.LambdaExpression propertyExpression) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+    }
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
         "lidation<TViewModel> as a base class.")]
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent
     {
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
@@ -132,20 +145,7 @@ namespace ReactiveUI.Validation.Components
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
     }
-    public class ObservableValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
-    {
-        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
-        public bool IsValid { get; }
-        public System.Collections.Generic.IEnumerable<string> Properties { get; }
-        public int PropertyCount { get; }
-        public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
-        public void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
-        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
-        public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-    }
-    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>
+    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation
     {
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -153,7 +153,7 @@ namespace ReactiveUI.Validation.Components
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidation
     {
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -23,11 +23,11 @@ namespace ReactiveUI.Validation.Collections
 }
 namespace ReactiveUI.Validation.Comparators
 {
-    public class ValidationStateComparer : System.Collections.Generic.EqualityComparer<ReactiveUI.Validation.States.ValidationState>
+    public class ValidationStateComparer : System.Collections.Generic.EqualityComparer<ReactiveUI.Validation.States.IValidationState>
     {
         public ValidationStateComparer() { }
-        public override bool Equals(ReactiveUI.Validation.States.ValidationState x, ReactiveUI.Validation.States.ValidationState y) { }
-        public override int GetHashCode(ReactiveUI.Validation.States.ValidationState obj) { }
+        public override bool Equals(ReactiveUI.Validation.States.IValidationState x, ReactiveUI.Validation.States.IValidationState y) { }
+        public override int GetHashCode(ReactiveUI.Validation.States.IValidationState obj) { }
     }
 }
 namespace ReactiveUI.Validation.Components.Abstractions
@@ -52,7 +52,7 @@ namespace ReactiveUI.Validation.Components.Abstractions
     {
         bool IsValid { get; }
         ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
     }
 }
 namespace ReactiveUI.Validation.Components
@@ -64,7 +64,7 @@ namespace ReactiveUI.Validation.Components
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
@@ -73,7 +73,7 @@ namespace ReactiveUI.Validation.Components
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
-        protected abstract System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable();
+        protected abstract System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable();
     }
     public sealed class BasePropertyValidation<TViewModel, TViewModelProperty> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -81,7 +81,7 @@ namespace ReactiveUI.Validation.Components
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Func<TViewModelProperty, bool> isValidFunc, System.Func<TViewModelProperty, bool, string> messageFunc) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Func<TViewModelProperty, bool> isValidFunc, string message) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [System.Obsolete("Consider using ObservableValidation<TViewModel, bool> instead.")]
@@ -92,7 +92,7 @@ namespace ReactiveUI.Validation.Components
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
@@ -118,14 +118,14 @@ namespace ReactiveUI.Validation.Components
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, string message) { }
     }
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public class ObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
-        protected ObservableValidationBase(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
+        public ObservableValidationBase(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
         public bool IsValid { get; }
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
@@ -135,7 +135,7 @@ namespace ReactiveUI.Validation.Components
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
+    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel>
     {
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -143,7 +143,7 @@ namespace ReactiveUI.Validation.Components
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel>
     {
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -160,7 +160,7 @@ namespace ReactiveUI.Validation.Contexts
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.ValidationText Text { get; }
         public System.IObservable<bool> Valid { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationStatusChange { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         public System.Collections.ObjectModel.ReadOnlyObservableCollection<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }
         public void Add(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
         public void Dispose() { }
@@ -231,7 +231,7 @@ namespace ReactiveUI.Validation.Extensions
     }
     public static class ValidationContextExtensions
     {
-        public static System.IObservable<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>> ObserveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
+        public static System.IObservable<System.Collections.Generic.IList<ReactiveUI.Validation.States.IValidationState>> ObserveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.ValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Since we support adding and removing validation rules dynamically, consider using" +
             " either the ObserveFor extension method, or BindValidation.")]
@@ -307,18 +307,29 @@ namespace ReactiveUI.Validation.Helpers
         public ValidationHelper(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation, System.IDisposable? cleanup = null) { }
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Message { get; }
-        public System.IObservable<ReactiveUI.Validation.States.ValidationState> ValidationChanged { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationChanged { get; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }
 }
 namespace ReactiveUI.Validation.States
 {
-    public sealed class ValidationState
+    public interface IValidationState
     {
+        bool IsValid { get; }
+        ReactiveUI.Validation.Collections.ValidationText Text { get; }
+    }
+    public class ValidationState : ReactiveUI.Validation.States.IValidationState
+    {
+        public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text) { }
+        public ValidationState(bool isValid, string text) { }
+        [System.Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text, ReactiveUI.Validation.Components.Abstractions.IValidationComponent component) { }
+        [System.Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, string text, ReactiveUI.Validation.Components.Abstractions.IValidationComponent component) { }
-        public ReactiveUI.Validation.Components.Abstractions.IValidationComponent Component { get; }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        [System.Obsolete("This property will be removed soon.")]
+        public ReactiveUI.Validation.Components.Abstractions.IValidationComponent? Component { get; }
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.ValidationText Text { get; }
     }
@@ -331,7 +342,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Func<System.ValueTuple<TProperty1, TProperty2>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Func<System.ValueTuple<TProperty1, TProperty2>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     public sealed class BasePropertyValidation<TViewModel, TProperty1, TProperty2, TProperty3> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -339,7 +350,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     public sealed class BasePropertyValidation<TViewModel, TProperty1, TProperty2, TProperty3, TProperty4> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -347,7 +358,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     public sealed class BasePropertyValidation<TViewModel, TProperty1, TProperty2, TProperty3, TProperty4, TProperty5> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -355,7 +366,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty5>> property5, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty5>> property5, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
     public sealed class BasePropertyValidation<TViewModel, TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
     {
@@ -363,7 +374,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty5>> property5, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty6>> property6, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6>, bool, ReactiveUI.Validation.Collections.ValidationText> message) { }
         public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty1>> property1, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty2>> property2, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty3>> property3, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty4>> property4, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty5>> property5, System.Linq.Expressions.Expression<System.Func<TViewModel, TProperty6>> property6, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6>, bool> isValidFunc, System.Func<System.ValueTuple<TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6>, bool, string> messageFunc) { }
         protected override void Dispose(bool disposing) { }
-        protected override System.IObservable<ReactiveUI.Validation.States.ValidationState> GetValidationChangeObservable() { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
     }
 }
 namespace ReactiveUI.Validation.ValidationBindings.Abstractions
@@ -375,13 +386,13 @@ namespace ReactiveUI.Validation.ValidationBindings
     public sealed class ValidationBinding : ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding, System.IDisposable
     {
         public void Dispose() { }
-        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<System.Collections.Generic.IList<ReactiveUI.Validation.States.ValidationState>, System.Collections.Generic.IList<TOut>> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter, bool strict = true)
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<System.Collections.Generic.IList<ReactiveUI.Validation.States.IValidationState>, System.Collections.Generic.IList<TOut>> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter, bool strict = true)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null, bool strict = true)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
-        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Action<ReactiveUI.Validation.States.ValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Action<ReactiveUI.Validation.States.IValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -118,43 +118,36 @@ namespace ReactiveUI.Validation.Components
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, string message) { }
     }
-    public class ObservableValidation : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
     {
-        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        protected ObservableValidationBase(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        protected ObservableValidationBase(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
         public bool IsValid { get; }
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
-        public void AddProperty(System.Linq.Expressions.LambdaExpression propertyExpression) { }
-        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
-        public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
-    }
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
-        "lidation<TViewModel> as a base class.")]
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent
-    {
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
-            "lidation<TViewModel> as a base class.")]
-        protected ObservableValidationBase(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
+        protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
             "ionComponent.")]
         public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation
+    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
     {
+        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidation
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
     {
+        public ObservableValidation(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, string> messageFunc) { }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -335,6 +335,7 @@ namespace ReactiveUI.Validation.States
     }
     public class ValidationState : ReactiveUI.Validation.States.IValidationState
     {
+        public static readonly ReactiveUI.Validation.States.ValidationState Valid;
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text) { }
         public ValidationState(bool isValid, string text) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -118,24 +118,34 @@ namespace ReactiveUI.Validation.Components
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, System.Func<TViewModel, bool, string> messageFunc) { }
         public ModelObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.Func<TViewModel, System.IObservable<bool>> validityObservable, string message) { }
     }
-    public class ObservableValidationBase<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
+        "lidation<TViewModel> as a base class.")]
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties<TViewModel>, ReactiveUI.Validation.Components.Abstractions.IValidationComponent
     {
-        public ObservableValidationBase(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        [System.Obsolete("This class is going to be removed in future versions. Consider using ObservableVa" +
+            "lidation<TViewModel> as a base class.")]
+        protected ObservableValidationBase(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, ReactiveUI.Validation.Collections.ValidationText> messageFunc) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
+            "ionComponent.")]
+        public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
+    }
+    public class ObservableValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    {
+        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
         public bool IsValid { get; }
         public System.Collections.Generic.IEnumerable<string> Properties { get; }
         public int PropertyCount { get; }
         public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
         public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
-        protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-        [System.Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidat" +
-            "ionComponent.")]
-        public bool ContainsProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property, bool exclusively = false) { }
+        public void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel>
+    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>
     {
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -143,7 +153,7 @@ namespace ReactiveUI.Validation.Components
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
     }
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel>
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidation<TViewModel>
     {
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
         public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
@@ -180,6 +190,8 @@ namespace ReactiveUI.Validation.Extensions
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static System.IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.IObservable<ReactiveUI.Validation.States.IValidationState> validationObservable)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Use the overload accepting just IObservable<bool> instead of Func<TViewModel, IOb" +
             "servable<bool>>")]
@@ -197,6 +209,8 @@ namespace ReactiveUI.Validation.Extensions
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.Func<TViewModel, System.IObservable<bool>> viewModelObservableProperty, string message)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.IObservable<bool> validationObservable, string message)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.IObservable<ReactiveUI.Validation.States.IValidationState> validationObservable)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TValue>(this TViewModel viewModel, System.IObservable<TValue> validationObservable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc)
             where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
@@ -323,8 +337,10 @@ namespace ReactiveUI.Validation.States
     {
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text) { }
         public ValidationState(bool isValid, string text) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text, ReactiveUI.Validation.Components.Abstractions.IValidationComponent component) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, string text, ReactiveUI.Validation.Components.Abstractions.IValidationComponent component) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
@@ -197,7 +197,7 @@ namespace ReactiveUI.Validation.Tests
             var arguments = new List<IValidationState>();
             var component = new ObservableValidation(stream);
             component.ValidationStatusChange.Subscribe(arguments.Add);
-            stream.OnNext(new ValidationState(true, string.Empty));
+            stream.OnNext(ValidationState.Valid);
 
             Assert.True(component.IsValid);
             Assert.Empty(component.Text!.ToSingleLine());

--- a/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
@@ -4,10 +4,12 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Reactive.Subjects;
 using ReactiveUI.Validation.Components;
 using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.Extensions;
+using ReactiveUI.Validation.States;
 using ReactiveUI.Validation.Tests.Models;
 using Xunit;
 
@@ -183,6 +185,36 @@ namespace ReactiveUI.Validation.Tests
             Assert.False(component.ContainsProperty<TestViewModel, string>(model => model.Name2));
             Assert.False(component.ContainsProperty<TestViewModel, string>(model => model.Name2, true));
             Assert.Throws<ArgumentNullException>(() => component.ContainsProperty<TestViewModel, string>(null!));
+        }
+
+        /// <summary>
+        /// Verifies that we support the simplest possible observable-based validation component.
+        /// </summary>
+        [Fact]
+        public void ShouldSupportMinimalObservableValidation()
+        {
+            var stream = new Subject<IValidationState>();
+            var arguments = new List<IValidationState>();
+            var component = new ObservableValidation(stream);
+            component.ValidationStatusChange.Subscribe(arguments.Add);
+            stream.OnNext(new ValidationState(true, string.Empty));
+
+            Assert.True(component.IsValid);
+            Assert.Empty(component.Text!.ToSingleLine());
+            Assert.Single(arguments);
+
+            Assert.True(arguments[0].IsValid);
+            Assert.Empty(arguments[0].Text.ToSingleLine());
+
+            const string errorMessage = "Errors exist.";
+            stream.OnNext(new ValidationState(false, errorMessage));
+
+            Assert.False(component.IsValid);
+            Assert.Equal(errorMessage, component.Text.ToSingleLine());
+            Assert.Equal(2, arguments.Count);
+
+            Assert.False(arguments[1].IsValid);
+            Assert.Equal(errorMessage, arguments[1].Text.ToSingleLine());
         }
     }
 }

--- a/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
@@ -195,7 +195,7 @@ namespace ReactiveUI.Validation.Tests
         {
             var stream = new Subject<IValidationState>();
             var arguments = new List<IValidationState>();
-            var component = new ObservableValidation(stream);
+            var component = new ObservableValidation<TestViewModel, bool>(stream);
             component.ValidationStatusChange.Subscribe(arguments.Add);
             stream.OnNext(ValidationState.Valid);
 

--- a/src/ReactiveUI.Validation.Tests/PropertyValidationTests.cs
+++ b/src/ReactiveUI.Validation.Tests/PropertyValidationTests.cs
@@ -108,19 +108,19 @@ namespace ReactiveUI.Validation.Tests
 
             model.Name = testValue;
 
-            var changes = new List<ValidationState>();
+            var changes = new List<IValidationState>();
 
             validation.ValidationStatusChange.Subscribe(v => changes.Add(v));
 
             Assert.Equal("The value 'bongo' is incorrect", validation.Text.ToSingleLine());
             Assert.Single(changes);
-            Assert.Equal(new ValidationState(false, "The value 'bongo' is incorrect", validation), changes[0], new ValidationStateComparer());
+            Assert.Equal(new ValidationState(false, "The value 'bongo' is incorrect"), changes[0], new ValidationStateComparer());
 
             model.Name = testRoot;
 
             Assert.Equal("The value 'bon' is incorrect", validation.Text.ToSingleLine());
             Assert.Equal(2, changes.Count);
-            Assert.Equal(new ValidationState(false, "The value 'bon' is incorrect", validation), changes[1], new ValidationStateComparer());
+            Assert.Equal(new ValidationState(false, "The value 'bon' is incorrect"), changes[1], new ValidationStateComparer());
         }
 
         /// <summary>

--- a/src/ReactiveUI.Validation/Comparators/ValidationStateComparer.cs
+++ b/src/ReactiveUI.Validation/Comparators/ValidationStateComparer.cs
@@ -11,18 +11,18 @@ namespace ReactiveUI.Validation.Comparators
 {
     /// <inheritdoc />
     /// <summary>
-    /// Utility class used to compare <see cref="ReactiveUI.Validation.States.ValidationState" /> instances.
+    /// Utility class used to compare <see cref="ReactiveUI.Validation.States.IValidationState" /> instances.
     /// </summary>
-    public class ValidationStateComparer : EqualityComparer<ValidationState>
+    public class ValidationStateComparer : EqualityComparer<IValidationState>
     {
         /// <summary>
-        /// Checks if two <see cref="ValidationState"/> objects are equals based on both
-        /// <see cref="ValidationState.IsValid"/> and <see cref="ValidationState.Component"/> properties.
+        /// Checks if two <see cref="IValidationState"/> objects are equals based on both
+        /// <see cref="IValidationState.IsValid"/> and <see cref="IValidationState.Text"/> properties.
         /// </summary>
-        /// <param name="x">Source <see cref="ValidationState"/> object.</param>
-        /// <param name="y">Target <see cref="ValidationState"/> object.</param>
+        /// <param name="x">Source <see cref="IValidationState"/> object.</param>
+        /// <param name="y">Target <see cref="IValidationState"/> object.</param>
         /// <returns>Returns true if both objects are equals, otherwise false.</returns>
-        public override bool Equals(ValidationState x, ValidationState y)
+        public override bool Equals(IValidationState x, IValidationState y)
         {
             if (x == null && y == null)
             {
@@ -34,12 +34,11 @@ namespace ReactiveUI.Validation.Comparators
                 return false;
             }
 
-            return x.IsValid == y.IsValid && x.Text.ToSingleLine() == y.Text.ToSingleLine()
-                                          && x.Component == y.Component;
+            return x.IsValid == y.IsValid && x.Text.ToSingleLine() == y.Text.ToSingleLine();
         }
 
         /// <inheritdoc />
-        public override int GetHashCode(ValidationState obj)
+        public override int GetHashCode(IValidationState obj)
         {
             if (obj == null)
             {

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidationComponent.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidationComponent.cs
@@ -27,6 +27,6 @@ namespace ReactiveUI.Validation.Components.Abstractions
         /// <summary>
         /// Gets the observable for validation state changes.
         /// </summary>
-        IObservable<ValidationState> ValidationStatusChange { get; }
+        IObservable<IValidationState> ValidationStatusChange { get; }
     }
 }

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI.Validation.Components
         private readonly ReplaySubject<bool> _isValidSubject = new ReplaySubject<bool>(1);
         private readonly HashSet<string> _propertyNames = new HashSet<string>();
         private readonly CompositeDisposable _disposables = new CompositeDisposable();
-        private IConnectableObservable<ValidationState>? _connectedChange;
+        private IConnectableObservable<IValidationState>? _connectedChange;
         private bool _isConnected;
         private bool _isValid;
         private ValidationText? _text;
@@ -64,7 +64,7 @@ namespace ReactiveUI.Validation.Components
         /// <summary>
         /// Gets the public mechanism indicating that the validation state has changed.
         /// </summary>
-        public IObservable<ValidationState> ValidationStatusChange
+        public IObservable<IValidationState> ValidationStatusChange
         {
             get
             {
@@ -140,8 +140,8 @@ namespace ReactiveUI.Validation.Components
         /// <summary>
         /// Get the validation change observable, implemented by concrete classes.
         /// </summary>
-        /// <returns>Returns the <see cref="ValidationState"/> collection.</returns>
-        protected abstract IObservable<ValidationState> GetValidationChangeObservable();
+        /// <returns>Returns the <see cref="IValidationState"/> collection.</returns>
+        protected abstract IObservable<IValidationState> GetValidationChangeObservable();
 
         /// <summary>
         /// Disposes of the managed resources.
@@ -279,7 +279,7 @@ namespace ReactiveUI.Validation.Components
         /// Get the validation change observable.
         /// </summary>
         /// <returns></returns>
-        protected override IObservable<ValidationState> GetValidationChangeObservable()
+        protected override IObservable<IValidationState> GetValidationChangeObservable()
         {
             Activate();
             return _valueSubject

--- a/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
@@ -193,9 +193,9 @@ namespace ReactiveUI.Validation.Components
     public abstract class ModelObservableValidationBase<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent, IPropertyValidationComponent<TViewModel>
     {
         [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
-        private readonly ReplaySubject<ValidationState> _lastValidationStateSubject = new ReplaySubject<ValidationState>(1);
+        private readonly ReplaySubject<IValidationState> _lastValidationStateSubject = new ReplaySubject<IValidationState>(1);
         private readonly HashSet<string> _propertyNames = new HashSet<string>();
-        private readonly IConnectableObservable<ValidationState> _validityConnectedObservable;
+        private readonly IConnectableObservable<IValidationState> _validityConnectedObservable;
         private readonly CompositeDisposable _disposables = new CompositeDisposable();
         private bool _isActive;
         private bool _isValid;
@@ -254,7 +254,7 @@ namespace ReactiveUI.Validation.Components
         }
 
         /// <inheritdoc/>
-        public IObservable<ValidationState> ValidationStatusChange
+        public IObservable<IValidationState> ValidationStatusChange
         {
             get
             {

--- a/src/ReactiveUI.Validation/Components/ObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation.cs
@@ -393,6 +393,22 @@ namespace ReactiveUI.Validation.Components
                 : _propertyNames.Contains(propertyName);
 
         /// <summary>
+        /// Adds a property to the list of properties which this validation is associated with.
+        /// </summary>
+        /// <typeparam name="TProp">Any type.</typeparam>
+        /// <param name="property">ViewModel property.</param>
+        public void AddProperty<TProp>(Expression<Func<TViewModel, TProp>> property)
+        {
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
+
+            var propertyName = property.Body.GetPropertyPath();
+            _propertyNames.Add(propertyName);
+        }
+
+        /// <summary>
         /// Disposes of the managed resources.
         /// </summary>
         /// <param name="disposing">
@@ -404,22 +420,6 @@ namespace ReactiveUI.Validation.Components
             {
                 _disposables.Dispose();
             }
-        }
-
-        /// <summary>
-        /// Adds a property to the list of this which this validation is associated with.
-        /// </summary>
-        /// <typeparam name="TProp">Any type.</typeparam>
-        /// <param name="property">ViewModel property.</param>
-        protected void AddProperty<TProp>(Expression<Func<TViewModel, TProp>> property)
-        {
-            if (property is null)
-            {
-                throw new ArgumentNullException(nameof(property));
-            }
-
-            var propertyName = property.Body.GetPropertyPath();
-            _propertyNames.Add(propertyName);
         }
 
         private void Activate()

--- a/src/ReactiveUI.Validation/Components/ObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation.cs
@@ -25,7 +25,7 @@ namespace ReactiveUI.Validation.Components
     /// Though in the passed observable more properties can be referenced via a call to WhenAnyValue.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ObservableValidation
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ObservableValidationBase<TViewModel, TValue>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableValidation{TViewModel,TValue,TProp}"/> class.
@@ -115,31 +115,19 @@ namespace ReactiveUI.Validation.Components
             IObservable<TValue> observable,
             Func<TViewModel, TValue, bool> isValidFunc,
             Func<TViewModel, TValue, bool, string> messageFunc)
-            : this(viewModel, viewModelProperty, observable, isValidFunc, (vm, value, isValid) =>
-                new ValidationText(messageFunc(vm, value, isValid)))
-        {
-        }
+            : base(viewModel, observable, isValidFunc, (vm, value, isValid) =>
+                new ValidationText(messageFunc(vm, value, isValid))) =>
+            AddProperty(viewModelProperty);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableValidation{TViewModel,TValue,TProp}"/> class.
         /// </summary>
-        /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="observable">Observable that updates the view model property validity.</param>
-        /// <param name="isValidFunc">Func to define if the viewModelProperty is valid or not.</param>
-        /// <param name="messageFunc">Func to define the validation error message.</param>
-        private ObservableValidation(
-            TViewModel viewModel,
+        public ObservableValidation(
             Expression<Func<TViewModel, TProp>> viewModelProperty,
-            IObservable<TValue> observable,
-            Func<TViewModel, TValue, bool> isValidFunc,
-            Func<TViewModel, TValue, bool, ValidationText> messageFunc)
-            : base(observable.Select(value =>
-            {
-                var isValid = isValidFunc(viewModel, value);
-                var message = messageFunc(viewModel, value, isValid);
-                return new ValidationState(isValid, message);
-            })) =>
+            IObservable<IValidationState> observable)
+            : base(observable) =>
             AddProperty(viewModelProperty);
     }
 
@@ -149,7 +137,7 @@ namespace ReactiveUI.Validation.Components
     /// A validation component that is based on an <see cref="IObservable{T}"/>.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
-    public sealed class ObservableValidation<TViewModel, TValue> : ObservableValidation
+    public sealed class ObservableValidation<TViewModel, TValue> : ObservableValidationBase<TViewModel, TValue>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableValidation{TViewModel,TValue}"/> class.
@@ -228,7 +216,7 @@ namespace ReactiveUI.Validation.Components
             IObservable<TValue> observable,
             Func<TViewModel, TValue, bool> isValidFunc,
             Func<TViewModel, TValue, bool, string> messageFunc)
-            : this(viewModel, observable, isValidFunc, (vm, value, isValid) =>
+            : base(viewModel, observable, isValidFunc, (vm, value, isValid) =>
                 new ValidationText(messageFunc(vm, value, isValid)))
         {
         }
@@ -236,21 +224,9 @@ namespace ReactiveUI.Validation.Components
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableValidation{TViewModel,TValue}"/> class.
         /// </summary>
-        /// <param name="viewModel">ViewModel instance.</param>
         /// <param name="observable">Observable that updates the view model property validity.</param>
-        /// <param name="isValidFunc">Func to define if the viewModelProperty is valid or not.</param>
-        /// <param name="messageFunc">Func to define the validation error message.</param>
-        private ObservableValidation(
-            TViewModel viewModel,
-            IObservable<TValue> observable,
-            Func<TViewModel, TValue, bool> isValidFunc,
-            Func<TViewModel, TValue, bool, ValidationText> messageFunc)
-            : base(observable.Select(value =>
-            {
-                var isValid = isValidFunc(viewModel, value);
-                var message = messageFunc(viewModel, value, isValid);
-                return new ValidationState(isValid, message);
-            }))
+        public ObservableValidation(IObservable<IValidationState> observable)
+            : base(observable)
         {
         }
     }
@@ -260,56 +236,8 @@ namespace ReactiveUI.Validation.Components
     /// <summary>
     /// A validation component that is based on an <see cref="IObservable{T}"/>.
     /// </summary>
-    [ExcludeFromCodeCoverage]
-    [Obsolete("This class is going to be removed in future versions. Consider using ObservableValidation<TViewModel> as a base class.")]
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ObservableValidation, IPropertyValidationComponent<TViewModel>
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ObservableValidationBase{TViewModel,TValue}"/> class.
-        /// </summary>
-        /// <param name="viewModel">ViewModel instance.</param>
-        /// <param name="observable">Observable that updates the view model property validity.</param>
-        /// <param name="isValidFunc">Func to define if the viewModelProperty is valid or not.</param>
-        /// <param name="messageFunc">Func to define the validation error message.</param>
-        [ExcludeFromCodeCoverage]
-        [Obsolete("This class is going to be removed in future versions. Consider using ObservableValidation<TViewModel> as a base class.")]
-        protected ObservableValidationBase(
-            TViewModel viewModel,
-            IObservable<TValue> observable,
-            Func<TViewModel, TValue, bool> isValidFunc,
-            Func<TViewModel, TValue, bool, ValidationText> messageFunc)
-            : base(observable.Select(value =>
-            {
-                var isValid = isValidFunc(viewModel, value);
-                var message = messageFunc(viewModel, value, isValid);
-                return new ValidationState(isValid, message);
-            }))
-        {
-        }
-
-        /// <inheritdoc/>
-        [ExcludeFromCodeCoverage]
-        [Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidationComponent.")]
-        public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
-        {
-            if (property is null)
-            {
-                throw new ArgumentNullException(nameof(property));
-            }
-
-            var propertyName = property.Body.GetPropertyPath();
-            return ContainsPropertyName(propertyName, exclusively);
-        }
-    }
-
-    /// <inheritdoc cref="ReactiveObject" />
-    /// <inheritdoc cref="IDisposable" />
-    /// <summary>
-    /// A validation component that is based on an <see cref="IObservable{T}"/>.
-    /// </summary>
-    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
-    public class ObservableValidation : ReactiveObject, IDisposable, IPropertyValidationComponent
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObject, IDisposable, IPropertyValidationComponent, IPropertyValidationComponent<TViewModel>
     {
         [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
         private readonly ReplaySubject<IValidationState> _isValidSubject = new ReplaySubject<IValidationState>(1);
@@ -321,10 +249,31 @@ namespace ReactiveUI.Validation.Components
         private ValidationText? _text;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ObservableValidation"/> class.
+        /// Initializes a new instance of the <see cref="ObservableValidationBase{TViewModel,TValue}"/> class.
+        /// </summary>
+        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="observable">Observable that updates the view model property validity.</param>
+        /// <param name="isValidFunc">Func to define if the viewModelProperty is valid or not.</param>
+        /// <param name="messageFunc">Func to define the validation error message.</param>
+        protected ObservableValidationBase(
+            TViewModel viewModel,
+            IObservable<TValue> observable,
+            Func<TViewModel, TValue, bool> isValidFunc,
+            Func<TViewModel, TValue, bool, ValidationText> messageFunc)
+            : this(observable.Select(value =>
+            {
+                var isValid = isValidFunc(viewModel, value);
+                var message = messageFunc(viewModel, value, isValid);
+                return new ValidationState(isValid, message);
+            }))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObservableValidationBase{TViewModel, TValue}"/> class.
         /// </summary>
         /// <param name="observable">Observable that updates the view model property validity.</param>
-        public ObservableValidation(IObservable<IValidationState> observable)
+        protected ObservableValidationBase(IObservable<IValidationState> observable)
         {
             _isValidSubject
                 .Do(state =>
@@ -387,26 +336,25 @@ namespace ReactiveUI.Validation.Components
         }
 
         /// <inheritdoc/>
+        [ExcludeFromCodeCoverage]
+        [Obsolete("Consider using the non-generic ContainsProperty of a non-generic IPropertyValidationComponent.")]
+        public bool ContainsProperty<TProp>(Expression<Func<TViewModel, TProp>> property, bool exclusively = false)
+        {
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
+
+            var propertyName = property.Body.GetPropertyPath();
+            return ContainsPropertyName(propertyName, exclusively);
+        }
+
+        /// <inheritdoc/>
         public bool ContainsPropertyName(string propertyName, bool exclusively = false) =>
             exclusively
                 ? _propertyNames.Contains(propertyName) &&
                   _propertyNames.Count == 1
                 : _propertyNames.Contains(propertyName);
-
-        /// <summary>
-        /// Adds a property to the list of properties which this validation is associated with.
-        /// </summary>
-        /// <param name="propertyExpression">ViewModel property lambda expression.</param>
-        public void AddProperty(LambdaExpression propertyExpression)
-        {
-            if (propertyExpression is null)
-            {
-                throw new ArgumentNullException(nameof(propertyExpression));
-            }
-
-            var propertyName = propertyExpression.Body.GetPropertyPath();
-            _propertyNames.Add(propertyName);
-        }
 
         /// <summary>
         /// Disposes of the managed resources.
@@ -420,6 +368,22 @@ namespace ReactiveUI.Validation.Components
             {
                 _disposables.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Adds a property to the list of this which this validation is associated with.
+        /// </summary>
+        /// <typeparam name="TProp">Any type.</typeparam>
+        /// <param name="property">ViewModel property.</param>
+        protected void AddProperty<TProp>(Expression<Func<TViewModel, TProp>> property)
+        {
+            if (property is null)
+            {
+                throw new ArgumentNullException(nameof(property));
+            }
+
+            var propertyName = property.Body.GetPropertyPath();
+            _propertyNames.Add(propertyName);
         }
 
         private void Activate()

--- a/src/ReactiveUI.Validation/Components/ObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation.cs
@@ -24,7 +24,8 @@ namespace ReactiveUI.Validation.Components
     /// A validation component that is based on an <see cref="IObservable{T}"/>. Validates a single property.
     /// Though in the passed observable more properties can be referenced via a call to WhenAnyValue.
     /// </summary>
-    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ObservableValidation<TViewModel>
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ObservableValidation
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableValidation{TViewModel,TValue,TProp}"/> class.
@@ -148,7 +149,7 @@ namespace ReactiveUI.Validation.Components
     /// A validation component that is based on an <see cref="IObservable{T}"/>.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
-    public sealed class ObservableValidation<TViewModel, TValue> : ObservableValidation<TViewModel>
+    public sealed class ObservableValidation<TViewModel, TValue> : ObservableValidation
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableValidation{TViewModel,TValue}"/> class.
@@ -262,7 +263,7 @@ namespace ReactiveUI.Validation.Components
     [ExcludeFromCodeCoverage]
     [Obsolete("This class is going to be removed in future versions. Consider using ObservableValidation<TViewModel> as a base class.")]
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
-    public abstract class ObservableValidationBase<TViewModel, TValue> : ObservableValidation<TViewModel>, IPropertyValidationComponent<TViewModel>
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ObservableValidation, IPropertyValidationComponent<TViewModel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObservableValidationBase{TViewModel,TValue}"/> class.
@@ -308,7 +309,7 @@ namespace ReactiveUI.Validation.Components
     /// A validation component that is based on an <see cref="IObservable{T}"/>.
     /// </summary>
     [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleType", Justification = "Same class just different generic parameters.")]
-    public class ObservableValidation<TViewModel> : ReactiveObject, IDisposable, IPropertyValidationComponent
+    public class ObservableValidation : ReactiveObject, IDisposable, IPropertyValidationComponent
     {
         [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
         private readonly ReplaySubject<IValidationState> _isValidSubject = new ReplaySubject<IValidationState>(1);
@@ -320,7 +321,7 @@ namespace ReactiveUI.Validation.Components
         private ValidationText? _text;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ObservableValidation{TViewModel}"/> class.
+        /// Initializes a new instance of the <see cref="ObservableValidation"/> class.
         /// </summary>
         /// <param name="observable">Observable that updates the view model property validity.</param>
         public ObservableValidation(IObservable<IValidationState> observable)
@@ -395,16 +396,15 @@ namespace ReactiveUI.Validation.Components
         /// <summary>
         /// Adds a property to the list of properties which this validation is associated with.
         /// </summary>
-        /// <typeparam name="TProp">Any type.</typeparam>
-        /// <param name="property">ViewModel property.</param>
-        public void AddProperty<TProp>(Expression<Func<TViewModel, TProp>> property)
+        /// <param name="propertyExpression">ViewModel property lambda expression.</param>
+        public void AddProperty(LambdaExpression propertyExpression)
         {
-            if (property is null)
+            if (propertyExpression is null)
             {
-                throw new ArgumentNullException(nameof(property));
+                throw new ArgumentNullException(nameof(propertyExpression));
             }
 
-            var propertyName = property.Body.GetPropertyPath();
+            var propertyName = propertyExpression.Body.GetPropertyPath();
             _propertyNames.Add(propertyName);
         }
 

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -35,7 +35,7 @@ namespace ReactiveUI.Validation.Contexts
     public class ValidationContext : ReactiveObject, IDisposable, IValidationComponent
     {
         private readonly SourceList<IValidationComponent> _validationSource = new SourceList<IValidationComponent>();
-        private readonly ReplaySubject<ValidationState> _validationStatusChange = new ReplaySubject<ValidationState>(1);
+        private readonly ReplaySubject<IValidationState> _validationStatusChange = new ReplaySubject<IValidationState>(1);
         private readonly ReplaySubject<bool> _validSubject = new ReplaySubject<bool>(1);
 
         private readonly ReadOnlyObservableCollection<IValidationComponent> _validations;
@@ -121,7 +121,7 @@ namespace ReactiveUI.Validation.Contexts
         }
 
         /// <inheritdoc />
-        public IObservable<ValidationState> ValidationStatusChange
+        public IObservable<IValidationState> ValidationStatusChange
         {
             get
             {
@@ -197,7 +197,7 @@ namespace ReactiveUI.Validation.Contexts
         {
             if (disposing)
             {
-                _disposables?.Dispose();
+                _disposables.Dispose();
             }
         }
 

--- a/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
@@ -222,7 +222,9 @@ namespace ReactiveUI.Validation.Extensions
                 throw new ArgumentNullException(nameof(validationObservable));
             }
 
-            return viewModel.RegisterValidation(new ObservableValidation(validationObservable));
+            return viewModel.RegisterValidation(
+                new ObservableValidation<TViewModel, bool>(
+                    validationObservable));
         }
 
         /// <summary>
@@ -365,9 +367,9 @@ namespace ReactiveUI.Validation.Extensions
                 throw new ArgumentNullException(nameof(validationObservable));
             }
 
-            var validation = new ObservableValidation(validationObservable);
-            validation.AddProperty(viewModelProperty);
-            return viewModel.RegisterValidation(validation);
+            return viewModel.RegisterValidation(
+                new ObservableValidation<TViewModel, bool, TViewModelProp>(
+                    viewModelProperty, validationObservable));
         }
 
         /// <summary>

--- a/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
@@ -13,6 +13,7 @@ using ReactiveUI.Validation.Components;
 using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.Contexts;
 using ReactiveUI.Validation.Helpers;
+using ReactiveUI.Validation.States;
 
 namespace ReactiveUI.Validation.Extensions
 {
@@ -196,6 +197,35 @@ namespace ReactiveUI.Validation.Extensions
         }
 
         /// <summary>
+        /// Setup a validation rule with a general observable based on <see cref="IValidationState"/>.
+        /// </summary>
+        /// <typeparam name="TViewModel">ViewModel type.</typeparam>
+        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="validationObservable">Observable to define if the viewModel is valid or not.</param>
+        /// <returns>Returns a <see cref="ValidationHelper"/> object.</returns>
+        /// <remarks>
+        /// It should be noted that the observable should provide an initial value, otherwise that can result
+        /// in an inconsistent performance.
+        /// </remarks>
+        public static ValidationHelper ValidationRule<TViewModel>(
+            this TViewModel viewModel,
+            IObservable<IValidationState> validationObservable)
+            where TViewModel : IReactiveObject, IValidatableViewModel
+        {
+            if (viewModel is null)
+            {
+                throw new ArgumentNullException(nameof(viewModel));
+            }
+
+            if (validationObservable is null)
+            {
+                throw new ArgumentNullException(nameof(validationObservable));
+            }
+
+            return viewModel.RegisterValidation(new ObservableValidation<TViewModel>(validationObservable));
+        }
+
+        /// <summary>
         /// Setup a validation rule with a general observable indicating validity and a static error message
         /// for the given view model property.
         /// </summary>
@@ -299,6 +329,45 @@ namespace ReactiveUI.Validation.Extensions
             return viewModel.RegisterValidation(
                 new ObservableValidation<TViewModel, TValue, TViewModelProp>(
                     viewModel, viewModelProperty, viewModelObservable, isValidFunc, messageFunc));
+        }
+
+        /// <summary>
+        /// Setup a validation rule with a general observable based on <see cref="IValidationState"/>.
+        /// </summary>
+        /// <typeparam name="TViewModel">ViewModel type.</typeparam>
+        /// <typeparam name="TViewModelProp">ViewModel property type.</typeparam>
+        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModelProperty">ViewModel property referenced in viewModelObservableProperty.</param>
+        /// <param name="validationObservable">Observable to define if the viewModel is valid or not.</param>
+        /// <returns>Returns a <see cref="ValidationHelper"/> object.</returns>
+        /// <remarks>
+        /// It should be noted that the observable should provide an initial value, otherwise that can result
+        /// in an inconsistent performance.
+        /// </remarks>
+        public static ValidationHelper ValidationRule<TViewModel, TViewModelProp>(
+            this TViewModel viewModel,
+            Expression<Func<TViewModel, TViewModelProp>> viewModelProperty,
+            IObservable<IValidationState> validationObservable)
+            where TViewModel : IReactiveObject, IValidatableViewModel
+        {
+            if (viewModel is null)
+            {
+                throw new ArgumentNullException(nameof(viewModel));
+            }
+
+            if (viewModelProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewModelProperty));
+            }
+
+            if (validationObservable is null)
+            {
+                throw new ArgumentNullException(nameof(validationObservable));
+            }
+
+            var validation = new ObservableValidation<TViewModel>(validationObservable);
+            validation.AddProperty(viewModelProperty);
+            return viewModel.RegisterValidation(validation);
         }
 
         /// <summary>

--- a/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
@@ -222,7 +222,7 @@ namespace ReactiveUI.Validation.Extensions
                 throw new ArgumentNullException(nameof(validationObservable));
             }
 
-            return viewModel.RegisterValidation(new ObservableValidation<TViewModel>(validationObservable));
+            return viewModel.RegisterValidation(new ObservableValidation(validationObservable));
         }
 
         /// <summary>
@@ -365,7 +365,7 @@ namespace ReactiveUI.Validation.Extensions
                 throw new ArgumentNullException(nameof(validationObservable));
             }
 
-            var validation = new ObservableValidation<TViewModel>(validationObservable);
+            var validation = new ObservableValidation(validationObservable);
             validation.AddProperty(viewModelProperty);
             return viewModel.RegisterValidation(validation);
         }

--- a/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
@@ -47,7 +47,7 @@ namespace ReactiveUI.Validation.Extensions
                 throw new ArgumentNullException(nameof(viewModelProperty));
             }
 
-            var initial = new[] { new ValidationState(true, string.Empty, context) };
+            var initial = new[] { ValidationState.Valid };
             return context
                 .Validations
                 .ToObservableChangeSet()

--- a/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
@@ -24,7 +24,7 @@ namespace ReactiveUI.Validation.Extensions
     public static class ValidationContextExtensions
     {
         /// <summary>
-        /// Resolves the <see cref="ValidationState"/> for a specified property in a reactive fashion.
+        /// Resolves the <see cref="IValidationState"/> for a specified property in a reactive fashion.
         /// </summary>
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
         /// <typeparam name="TViewModelProperty">ViewModel property type.</typeparam>
@@ -32,7 +32,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="strict">Indicates if the ViewModel property to find is unique.</param>
         /// <returns>Returns a collection of <see cref="BasePropertyValidation{TViewModel}"/> objects.</returns>
-        public static IObservable<IList<ValidationState>> ObserveFor<TViewModel, TViewModelProperty>(
+        public static IObservable<IList<IValidationState>> ObserveFor<TViewModel, TViewModelProperty>(
             this ValidationContext context,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             bool strict = true)

--- a/src/ReactiveUI.Validation/Helpers/ValidationHelper.cs
+++ b/src/ReactiveUI.Validation/Helpers/ValidationHelper.cs
@@ -57,7 +57,7 @@ namespace ReactiveUI.Validation.Helpers
         /// <summary>
         /// Gets the observable for validation state changes.
         /// </summary>
-        public IObservable<ValidationState> ValidationChanged => _validation.ValidationStatusChange;
+        public IObservable<IValidationState> ValidationChanged => _validation.ValidationStatusChange;
 
         /// <inheritdoc/>
         public void Dispose()

--- a/src/ReactiveUI.Validation/States/IValidationState.cs
+++ b/src/ReactiveUI.Validation/States/IValidationState.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Validation.Collections;
+
+namespace ReactiveUI.Validation.States
+{
+    /// <summary>
+    /// Represents the validation state of a validation component.
+    /// </summary>
+    public interface IValidationState
+    {
+        /// <summary>
+        /// Gets the validation text.
+        /// </summary>
+        ValidationText Text { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the validation is currently valid or not.
+        /// </summary>
+        bool IsValid { get; }
+    }
+}

--- a/src/ReactiveUI.Validation/States/ValidationState.cs
+++ b/src/ReactiveUI.Validation/States/ValidationState.cs
@@ -16,6 +16,11 @@ namespace ReactiveUI.Validation.States
     public class ValidationState : IValidationState
     {
         /// <summary>
+        /// Indicates a valid state.
+        /// </summary>
+        public static readonly ValidationState Valid = new ValidationState(true, string.Empty);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ValidationState"/> class.
         /// </summary>
         /// <param name="isValid">Determines if the property is valid or not.</param>

--- a/src/ReactiveUI.Validation/States/ValidationState.cs
+++ b/src/ReactiveUI.Validation/States/ValidationState.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Components.Abstractions;
 
@@ -11,14 +13,37 @@ namespace ReactiveUI.Validation.States
     /// <summary>
     /// Represents the validation state of a validation component.
     /// </summary>
-    public sealed class ValidationState
+    public class ValidationState : IValidationState
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationState"/> class.
         /// </summary>
         /// <param name="isValid">Determines if the property is valid or not.</param>
         /// <param name="text">Validation text.</param>
+        public ValidationState(bool isValid, string text)
+            : this(isValid, new ValidationText(text))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationState"/> class.
+        /// </summary>
+        /// <param name="isValid">Determines if the property is valid or not.</param>
+        /// <param name="text">Validation text.</param>
+        public ValidationState(bool isValid, ValidationText text)
+        {
+            IsValid = isValid;
+            Text = text ?? throw new ArgumentNullException(nameof(text));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationState"/> class.
+        /// </summary>
+        /// <param name="isValid">Determines if the property is valid or not.</param>
+        /// <param name="text">Validation text.</param>
         /// <param name="component">Validation property.</param>
+        [ExcludeFromCodeCoverage]
+        [Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, string text, IValidationComponent component)
             : this(isValid, new ValidationText(text), component)
         {
@@ -30,17 +55,21 @@ namespace ReactiveUI.Validation.States
         /// <param name="isValid">Determines if the property is valid or not.</param>
         /// <param name="text">Validation text.</param>
         /// <param name="component">Validation property.</param>
+        [ExcludeFromCodeCoverage]
+        [Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, ValidationText text, IValidationComponent component)
         {
             IsValid = isValid;
-            Text = text ?? throw new System.ArgumentNullException(nameof(text));
-            Component = component ?? throw new System.ArgumentNullException(nameof(component));
+            Text = text ?? throw new ArgumentNullException(nameof(text));
+            Component = component;
         }
 
         /// <summary>
         /// Gets the associated component.
         /// </summary>
-        public IValidationComponent Component { get; }
+        [ExcludeFromCodeCoverage]
+        [Obsolete("This property will be removed soon.")]
+        public IValidationComponent? Component { get; }
 
         /// <summary>
         /// Gets a value indicating whether the validation is currently valid or not.

--- a/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.cs
+++ b/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.cs
@@ -119,7 +119,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         private (TProperty1, TProperty2) LastValue { get; set; }
 
         /// <inheritdoc/>
-        protected override IObservable<ValidationState> GetValidationChangeObservable()
+        protected override IObservable<IValidationState> GetValidationChangeObservable()
         {
             Activate();
 
@@ -265,7 +265,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         private (TProperty1, TProperty2, TProperty3) LastValue { get; set; }
 
         /// <inheritdoc/>
-        protected override IObservable<ValidationState> GetValidationChangeObservable()
+        protected override IObservable<IValidationState> GetValidationChangeObservable()
         {
             Activate();
 
@@ -420,7 +420,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         private (TProperty1, TProperty2, TProperty3, TProperty4) LastValue { get; set; }
 
         /// <inheritdoc/>
-        protected override IObservable<ValidationState> GetValidationChangeObservable()
+        protected override IObservable<IValidationState> GetValidationChangeObservable()
         {
             Activate();
 
@@ -584,7 +584,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         private (TProperty1, TProperty2, TProperty3, TProperty4, TProperty5) LastValue { get; set; }
 
         /// <inheritdoc/>
-        protected override IObservable<ValidationState> GetValidationChangeObservable()
+        protected override IObservable<IValidationState> GetValidationChangeObservable()
         {
             Activate();
 
@@ -757,7 +757,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
         private (TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6) LastValue { get; set; }
 
         /// <inheritdoc/>
-        protected override IObservable<ValidationState> GetValidationChangeObservable()
+        protected override IObservable<IValidationState> GetValidationChangeObservable()
         {
             Activate();
 

--- a/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.tt
+++ b/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.tt
@@ -128,7 +128,7 @@ _disposables.Add(_valueSubject.Subscribe(v => LastValue = v));
         private (<#= String.Join(", ",templParams) #>) LastValue { get; set; }
 
         /// <inheritdoc/>
-        protected override IObservable<ValidationState> GetValidationChangeObservable()
+        protected override IObservable<IValidationState> GetValidationChangeObservable()
         {
             Activate();
 

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -189,7 +189,7 @@ namespace ReactiveUI.Validation.ValidationBindings
                         .WhenAnyValue(viewModelHelperProperty)
                         .SelectMany(helper => helper != null
                             ? helper.ValidationChanged
-                            : Observable.Return(new ValidationState(true, string.Empty, viewModel!.ValidationContext))))
+                            : Observable.Return(ValidationState.Valid)))
                 .Switch()
                 .Select(vc => formatter.Format(vc.Text));
 
@@ -246,7 +246,7 @@ namespace ReactiveUI.Validation.ValidationBindings
                         .WhenAnyValue(viewModelHelperProperty)
                         .SelectMany(helper => helper != null
                             ? helper.ValidationChanged
-                            : Observable.Return(new ValidationState(true, string.Empty, viewModel!.ValidationContext))))
+                            : Observable.Return(ValidationState.Valid)))
                 .Switch()
                 .Do(state => action(state, formatter.Format(state.Text)))
                 .Select(_ => Unit.Default);

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -102,7 +102,7 @@ namespace ReactiveUI.Validation.ValidationBindings
         public static IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(
             TView view,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
-            Action<IList<ValidationState>, IList<TOut>> action,
+            Action<IList<IValidationState>, IList<TOut>> action,
             IValidationTextFormatter<TOut> formatter,
             bool strict = true)
             where TView : IViewFor<TViewModel>
@@ -213,7 +213,7 @@ namespace ReactiveUI.Validation.ValidationBindings
         public static IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(
             TView view,
             Expression<Func<TViewModel?, ValidationHelper>> viewModelHelperProperty,
-            Action<ValidationState, TOut> action,
+            Action<IValidationState, TOut> action,
             IValidationTextFormatter<TOut> formatter)
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR implements the API specification eloquently argued and formulated by @thargy in https://github.com/reactiveui/ReactiveUI.Validation/issues/123#issue-721810174

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, there is no way to customize a `ValidationState`.
Also, there is no `ValidationRule` overload accepting a `ValidationState`.
See https://github.com/reactiveui/ReactiveUI.Validation/issues/123 for more information regarding this topic.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, we are using `IValidationState` where possible, and this simplifies the use of complex and extended validation rules. Now we have two more overloads for the `ValidationRule` extension method, one of the rules accepts a view model and `IObservable<IValidationState>`, and another one accepts a view model, a property, and an `IObservable<IValidationState>`. This allows ReactiveUI.Validation users to fully control how an object implementing `IValidtionState` is created.

**What might this PR break?**

One potential breaking change is described in https://github.com/reactiveui/ReactiveUI.Validation/issues/123#issuecomment-708721343 e.g. there is no `.Component` property on the new `IValidationState` interface, so the code relying on that property might break. Hopefully, there aren't many people who are relying on that `.Component` property. And if they do, a potential workaround would be to just cast `IObservable<IValidationState>` to `IObservable<ValidationState>` by adding a call to `.OfType<ValidationState>()`, e.g:

```cs
IValidationComponent validation = new ValidationContext();
validation.ValidationStatusChange.OfType<ValidationState>() // IValidationState -> ValidationState
```

However, we discourage the use of `ValidationState.Component` obsolete property as we are going to remove it in the future.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (the work is in progress)
- [x] Docs have been added / updated

**Other information**:

We need to carefully review the API changes to avoid introducing additional breaking changes.