### PR TITLE
Refactor: change validation state to have a static valid state

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ IObservable<IValidationState> usernameNotEmpty =
     this.WhenAnyValue(x => x.UserName)
         .Select(name => string.IsNullOrEmpty(name) 
             ? new ValidationState(false, "The username must not be empty")
-            : new ValidationState(true, string.Empty));
+            : ValidationState.Valid);
 
 this.ValidationRule(vm => vm.UserName, usernameNotEmpty);
 ```

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -335,6 +335,7 @@ namespace ReactiveUI.Validation.States
     }
     public class ValidationState : ReactiveUI.Validation.States.IValidationState
     {
+        public static readonly ReactiveUI.Validation.States.ValidationState Valid;
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text) { }
         public ValidationState(bool isValid, string text) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -335,6 +335,7 @@ namespace ReactiveUI.Validation.States
     }
     public class ValidationState : ReactiveUI.Validation.States.IValidationState
     {
+        public static readonly ReactiveUI.Validation.States.ValidationState Valid;
         public ValidationState(bool isValid, ReactiveUI.Validation.Collections.ValidationText text) { }
         public ValidationState(bool isValid, string text) { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
@@ -197,7 +197,7 @@ namespace ReactiveUI.Validation.Tests
             var arguments = new List<IValidationState>();
             var component = new ObservableValidation(stream);
             component.ValidationStatusChange.Subscribe(arguments.Add);
-            stream.OnNext(new ValidationState(true, string.Empty));
+            stream.OnNext(ValidationState.Valid);
 
             Assert.True(component.IsValid);
             Assert.Empty(component.Text!.ToSingleLine());

--- a/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
@@ -47,7 +47,7 @@ namespace ReactiveUI.Validation.Extensions
                 throw new ArgumentNullException(nameof(viewModelProperty));
             }
 
-            var initial = new[] { new ValidationState(true, string.Empty, context) };
+            var initial = new[] { ValidationState.Valid };
             return context
                 .Validations
                 .ToObservableChangeSet()

--- a/src/ReactiveUI.Validation/States/ValidationState.cs
+++ b/src/ReactiveUI.Validation/States/ValidationState.cs
@@ -19,7 +19,7 @@ namespace ReactiveUI.Validation.States
         /// Indicates a valid state.
         /// </summary>
         public static readonly ValidationState Valid = new ValidationState(true, string.Empty);
-    
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationState"/> class.
         /// </summary>

--- a/src/ReactiveUI.Validation/States/ValidationState.cs
+++ b/src/ReactiveUI.Validation/States/ValidationState.cs
@@ -16,6 +16,11 @@ namespace ReactiveUI.Validation.States
     public class ValidationState : IValidationState
     {
         /// <summary>
+        /// Indicates a valid state.
+        /// </summary>
+        public static readonly ValidationState Valid = new ValidationState(true, string.Empty);
+    
+        /// <summary>
         /// Initializes a new instance of the <see cref="ValidationState"/> class.
         /// </summary>
         /// <param name="isValid">Determines if the property is valid or not.</param>

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -189,7 +189,7 @@ namespace ReactiveUI.Validation.ValidationBindings
                         .WhenAnyValue(viewModelHelperProperty)
                         .SelectMany(helper => helper != null
                             ? helper.ValidationChanged
-                            : Observable.Return(new ValidationState(true, string.Empty, viewModel!.ValidationContext))))
+                            : Observable.Return(ValidationState.Valid)))
                 .Switch()
                 .Select(vc => formatter.Format(vc.Text));
 
@@ -246,7 +246,7 @@ namespace ReactiveUI.Validation.ValidationBindings
                         .WhenAnyValue(viewModelHelperProperty)
                         .SelectMany(helper => helper != null
                             ? helper.ValidationChanged
-                            : Observable.Return(new ValidationState(true, string.Empty, viewModel!.ValidationContext))))
+                            : Observable.Return(ValidationState.Valid)))
                 .Switch()
                 .Do(state => action(state, formatter.Format(state.Text)))
                 .Select(_ => Unit.Default);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This is discussed in https://github.com/reactiveui/ReactiveUI.Validation/pull/130#issuecomment-710691834.  Essentially, with the obsolescence of `Component` from `ValidationState` then the most common 'valid' state is identical and so should be exposed as a static readonly property.  This decreases memory utilisation.

**What is the current behavior?**
The same object risks being created repeatedly in common usage.

**What is the new behavior?**
Consumers can provide the static singleton instance.

**What might this PR break?**
All impacts relate to the now obsolete `Component` property, and could result in `NullReferenceExceptions` being thrown where consumers previously relied on the component.  This is considered highly unlikely, and ultimately the property is due to be removed entirely.

* The initial valid state created in the `ObserveFor<>` extension method now has a `null` `Component` property, whereas it would previously reference the supplied `ValidationContext`.
* The initial valid state created in the `ForValidationHelperProperty<>` extension methods now have a `null` `Component` property, whereas they would previously reference the supplied viewmodel's `ValidationContext`.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:

