### PR TITLE
housekeeping: Reference ReactiveUI.Android*, Customize Descriptions

### DIFF
--- a/src/ReactiveUI.Validation.AndroidSupport/ReactiveUI.Validation.AndroidSupport.csproj
+++ b/src/ReactiveUI.Validation.AndroidSupport/ReactiveUI.Validation.AndroidSupport.csproj
@@ -2,13 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>MonoAndroid90</TargetFramework>
+    <PackageDescription>Provides ReactiveUI.Validation extensions for the Android Support Library</PackageDescription>
+    <PackageId>ReactiveUI.Validation.AndroidSupport</PackageId>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Android.Support.Design" Version="28.*" />
+    <PackageReference Include="Xamarin.Android.Support.Design" Version="27.*" />
+    <PackageReference Include="ReactiveUI.AndroidSupport" Version="11.*" />
     <PackageReference Include="ReactiveUI" Version="11.*" />
   </ItemGroup>
 

--- a/src/ReactiveUI.Validation.AndroidX/ReactiveUI.Validation.AndroidX.csproj
+++ b/src/ReactiveUI.Validation.AndroidX/ReactiveUI.Validation.AndroidX.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>MonoAndroid90</TargetFramework>
+    <PackageDescription>Provides ReactiveUI.Validation extensions for the AndroidX Library</PackageDescription>
+    <PackageId>ReactiveUI.Validation.AndroidX</PackageId>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -9,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.*" />
+    <PackageReference Include="ReactiveUI.AndroidX" Version="11.*" />
     <PackageReference Include="ReactiveUI" Version="11.*" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

In this PR we are referencing main `ReactiveUI.AndroidSupport` and `ReactiveUI.AndroidX` packages https://github.com/reactiveui/ReactiveUI.Validation/pull/134#discussion_r507110971 Also, this PR customizes the descriptions of the new `ReactiveUI.Validation.AndroidX` and `ReactiveUI.Validation.AndroidSupport` packages.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, the packages have no unique descriptions and aren't referencing the main ReactiveUI Android support packages.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, the descriptions are updated, and the references are added.

**What might this PR break?**

Nothing.