### PR TITLE
Fixes ReactiveValidationObject NullReferenceException and enhances performance and thread-safety of ValidationText

### DIFF
--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -11,6 +11,7 @@ namespace ReactiveUI.Validation.Collections
     public class ValidationText : System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
     {
         public static readonly ReactiveUI.Validation.Collections.ValidationText Empty;
+        public static readonly ReactiveUI.Validation.Collections.ValidationText None;
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overloa" +
             "d instead.")]

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -10,15 +10,29 @@ namespace ReactiveUI.Validation.Collections
 {
     public class ValidationText : System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
     {
+        public static readonly ReactiveUI.Validation.Collections.ValidationText Empty;
+        [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overloa" +
+            "d instead.")]
         public ValidationText() { }
+        [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(IEnumerab" +
+            "le<ValidationText>) overload instead.")]
         public ValidationText(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Collections.ValidationText> validationTexts) { }
+        [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(string) o" +
+            "verload instead.")]
         public ValidationText(string text) { }
         public int Count { get; }
         public string this[int index] { get; }
+        [System.Obsolete("ValidationText will be made immutable in future versions, please do not use the A" +
+            "dd(string) method.")]
         public void Add(string text) { }
+        [System.Obsolete("ValidationText will be made immutable in future versions, please do not use the C" +
+            "lear() method.")]
         public void Clear() { }
         public System.Collections.Generic.IEnumerator<string> GetEnumerator() { }
         public string ToSingleLine(string? separator = ",") { }
+        public static ReactiveUI.Validation.Collections.ValidationText Create(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Collections.ValidationText> validationTexts) { }
+        public static ReactiveUI.Validation.Collections.ValidationText Create(System.Collections.Generic.IEnumerable<string> validationTexts) { }
+        public static ReactiveUI.Validation.Collections.ValidationText Create(params string[] validationTexts) { }
     }
 }
 namespace ReactiveUI.Validation.Comparators

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -11,20 +11,25 @@ namespace ReactiveUI.Validation.Collections
     public class ValidationText : System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
     {
         public static readonly ReactiveUI.Validation.Collections.ValidationText Empty;
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overloa" +
             "d instead.")]
         public ValidationText() { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(IEnumerab" +
             "le<ValidationText>) overload instead.")]
         public ValidationText(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Collections.ValidationText> validationTexts) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(string) o" +
             "verload instead.")]
         public ValidationText(string text) { }
         public int Count { get; }
         public string this[int index] { get; }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("ValidationText will be made immutable in future versions, please do not use the A" +
             "dd(string) method.")]
         public void Add(string text) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("ValidationText will be made immutable in future versions, please do not use the C" +
             "lear() method.")]
         public void Clear() { }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -11,6 +11,7 @@ namespace ReactiveUI.Validation.Collections
     public class ValidationText : System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
     {
         public static readonly ReactiveUI.Validation.Collections.ValidationText Empty;
+        public static readonly ReactiveUI.Validation.Collections.ValidationText None;
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overloa" +
             "d instead.")]

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -10,15 +10,29 @@ namespace ReactiveUI.Validation.Collections
 {
     public class ValidationText : System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
     {
+        public static readonly ReactiveUI.Validation.Collections.ValidationText Empty;
+        [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overloa" +
+            "d instead.")]
         public ValidationText() { }
+        [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(IEnumerab" +
+            "le<ValidationText>) overload instead.")]
         public ValidationText(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Collections.ValidationText> validationTexts) { }
+        [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(string) o" +
+            "verload instead.")]
         public ValidationText(string text) { }
         public int Count { get; }
         public string this[int index] { get; }
+        [System.Obsolete("ValidationText will be made immutable in future versions, please do not use the A" +
+            "dd(string) method.")]
         public void Add(string text) { }
+        [System.Obsolete("ValidationText will be made immutable in future versions, please do not use the C" +
+            "lear() method.")]
         public void Clear() { }
         public System.Collections.Generic.IEnumerator<string> GetEnumerator() { }
         public string ToSingleLine(string? separator = ",") { }
+        public static ReactiveUI.Validation.Collections.ValidationText Create(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Collections.ValidationText> validationTexts) { }
+        public static ReactiveUI.Validation.Collections.ValidationText Create(System.Collections.Generic.IEnumerable<string> validationTexts) { }
+        public static ReactiveUI.Validation.Collections.ValidationText Create(params string[] validationTexts) { }
     }
 }
 namespace ReactiveUI.Validation.Comparators

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -11,20 +11,25 @@ namespace ReactiveUI.Validation.Collections
     public class ValidationText : System.Collections.Generic.IEnumerable<string>, System.Collections.IEnumerable
     {
         public static readonly ReactiveUI.Validation.Collections.ValidationText Empty;
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overloa" +
             "d instead.")]
         public ValidationText() { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(IEnumerab" +
             "le<ValidationText>) overload instead.")]
         public ValidationText(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Collections.ValidationText> validationTexts) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(string) o" +
             "verload instead.")]
         public ValidationText(string text) { }
         public int Count { get; }
         public string this[int index] { get; }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("ValidationText will be made immutable in future versions, please do not use the A" +
             "dd(string) method.")]
         public void Add(string text) { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("ValidationText will be made immutable in future versions, please do not use the C" +
             "lear() method.")]
         public void Clear() { }

--- a/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
@@ -706,7 +706,7 @@ namespace ReactiveUI.Validation.Tests
             public CustomValidationState(bool isValid, string message)
             {
                 IsValid = isValid;
-                Text = new ValidationText(isValid ? string.Empty : message);
+                Text = isValid ? ValidationText.Empty : ValidationText.Create(message);
             }
 
             public ValidationText Text { get; }

--- a/src/ReactiveUI.Validation.Tests/ValidationTextTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationTextTests.cs
@@ -1,5 +1,7 @@
-// Licensed under the Apache License, Version 2.0 (the "License").
-// See the LICENSE file in the project root for more information.
+// Copyright (c) 2020 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReactiveUI.Validation.Tests/ValidationTextTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationTextTests.cs
@@ -1,0 +1,229 @@
+// Licensed under the Apache License, Version 2.0 (the "License").
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ReactiveUI.Validation.Collections;
+using ReactiveUI.Validation.Contexts;
+using Xunit;
+
+namespace ReactiveUI.Validation.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="ValidationContext"/>.
+    /// </summary>
+    public class ValidationTextTests
+    {
+        /// <summary>
+        /// Verifies that <see cref="ValidationText.None"/> is genuinely empty.
+        /// </summary>
+        [Fact]
+        public void NoneValidationTextIsEmpty()
+        {
+            ValidationText vt = ValidationText.None;
+
+            Assert.Equal(0, vt.Count);
+
+            // Calling Count() checks the enumeration returns no results, unlike the Count property.
+#pragma warning disable CA1829 // Use Length/Count property instead of Count() when available
+            Assert.Equal(0, vt.Count());
+#pragma warning restore CA1829 // Use Length/Count property instead of Count() when available
+            Assert.Equal(string.Empty, vt.ToSingleLine());
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="ValidationText.Empty"/> has a single empty item.
+        /// </summary>
+        [Fact]
+        public void EmptyValidationTextIsSingleEmpty()
+        {
+            ValidationText vt = ValidationText.Empty;
+
+            Assert.Equal(1, vt.Count);
+
+            // Calling Count() checks the enumeration returns no results, unlike the Count property.
+#pragma warning disable CA1829 // Use Length/Count property instead of Count() when available
+            Assert.Equal(1, vt.Count());
+#pragma warning restore CA1829 // Use Length/Count property instead of Count() when available
+            Assert.Same(string.Empty, vt.Single());
+            Assert.Equal(string.Empty, vt.ToSingleLine());
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(string[])"/> without parameters returns <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void ParameterlessCreateReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create();
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{string})"/> with an empty enumerable <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void CreateEmptyStringEnumerableReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create((IEnumerable<string>)Array.Empty<string>());
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{ValidationText})"/> with an empty enumerable <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void CreateEmptyValidationTextEnumerableReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create(Array.Empty<ValidationText>());
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(string[])"/> with <see langword="null"/> returns <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void CreateNullReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create((string)null);
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{string})"/> with <see langword="null"/> enumerable returns <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void CreateNullStringEnumerableReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create((IEnumerable<string>)null);
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{ValidationText})"/> with <see langword="null"/> returns <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void CreateNullValidationTextEnumerableReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create((IEnumerable<ValidationText>)null);
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{string})"/> with an enumerable containing <see langword="null"/> returns <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void CreateNullItemStringEnumerableReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create((IEnumerable<string>)new string[] { null });
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{ValidationText})"/>  with an enumerable containing <see cref="ValidationText.None"/> returns <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void CreateNoneItemValidationTextEnumerableReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create(new[] { ValidationText.None });
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{string})"/>  with an enumerable containing <see cref="ValidationText.None"/> returns <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void CreateNoneItemStringEnumerableReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create(ValidationText.None);
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(string[])"/> with <see cref="string.Empty"/> returns <see cref="ValidationText.Empty"/>.
+        /// </summary>
+        [Fact]
+        public void CreateStringEmptyReturnsEmpty()
+        {
+            ValidationText vt = ValidationText.Create(string.Empty);
+
+            Assert.Same(ValidationText.Empty, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{string})"/> with an enumerable containing <see cref="string.Empty"/> returns <see cref="ValidationText.Empty"/>.
+        /// </summary>
+        [Fact]
+        public void CreateSingleStringEmptyReturnsEmpty()
+        {
+            ValidationText vt = ValidationText.Create((IEnumerable<string>)new[] { string.Empty });
+
+            Assert.Same(ValidationText.Empty, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{string})"/> with an enumerable containing <see cref="string.Empty"/> returns <see cref="ValidationText.Empty"/>.
+        /// </summary>
+        [Fact]
+        public void CreateValidationTextEmptyReturnsEmpty()
+        {
+            ValidationText vt = ValidationText.Create(new[] { ValidationText.Empty });
+
+            Assert.Same(ValidationText.Empty, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{ValidationText})"/> with an enumerable containing two <see cref="ValidationText.None"/> returns <see cref="ValidationText.None"/>.
+        /// </summary>
+        [Fact]
+        public void CombineValidationTextNoneReturnsNone()
+        {
+            ValidationText vt = ValidationText.Create(new[] { ValidationText.None, ValidationText.None });
+
+            Assert.Same(ValidationText.None, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{ValidationText})"/> with an enumerable containing <see cref="ValidationText.None"/> and <see cref="ValidationText.Empty"/> returns <see cref="ValidationText.Empty"/>.
+        /// </summary>
+        [Fact]
+        public void CombineValidationTextEmptyAndNoneReturnsEmpty()
+        {
+            ValidationText vt = ValidationText.Create(new[] { ValidationText.None, ValidationText.Empty });
+
+            Assert.Same(ValidationText.Empty, vt);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="ValidationText.Create(IEnumerable{ValidationText})"/> with an enumerable containing two <see cref="ValidationText.Empty"/>
+        /// returns a single <see cref="ValidationText"/> with two empty strings.
+        /// </summary>
+        [Fact]
+        public void CombineValidationTextEmptyReturnsTwoEmpty()
+        {
+            ValidationText vt = ValidationText.Create(new[] { ValidationText.Empty, ValidationText.Empty });
+
+            Assert.NotSame(ValidationText.Empty, vt);
+            Assert.Equal(2, vt.Count);
+
+            // Calling Count() checks the enumeration returns no results, unlike the Count property.
+#pragma warning disable CA1829 // Use Length/Count property instead of Count() when available
+            Assert.Equal(2, vt.Count());
+#pragma warning restore CA1829 // Use Length/Count property instead of Count() when available
+            Assert.Equal(string.Empty, vt[0]);
+            Assert.Equal(string.Empty, vt[1]);
+
+            Assert.Equal("|", vt.ToSingleLine("|"));
+        }
+    }
+}

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -3,8 +3,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ReactiveUI.Validation.Collections
 {
@@ -13,12 +15,20 @@ namespace ReactiveUI.Validation.Collections
     /// </summary>
     public class ValidationText : IEnumerable<string>
     {
-        private readonly List<string> _texts = new List<string>();
+        /// <summary>
+        /// The empty validation text singleton instance.
+        /// </summary>
+        public static readonly ValidationText Empty = new ValidationText(Array.Empty<string>());
+
+        // TODO When Add() & Clear() are obsolesced this should be made read-only.
+        private /* readonly */ string[] _texts;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationText"/> class.
         /// </summary>
+        [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overload instead.")]
         public ValidationText()
+            : this(Array.Empty<string>())
         {
         }
 
@@ -26,32 +36,31 @@ namespace ReactiveUI.Validation.Collections
         /// Initializes a new instance of the <see cref="ValidationText"/> class.
         /// </summary>
         /// <param name="text">Text to be added in the collection.</param>
+        [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(string) overload instead.")]
         public ValidationText(string text)
+        :this(new[] { text })
         {
-            _texts.Add(text);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationText"/> class.
         /// </summary>
         /// <param name="validationTexts"><see cref="ValidationText"/> collection to be added into the text collection.</param>
+        [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(IEnumerable<ValidationText>) overload instead.")]
         public ValidationText(IEnumerable<ValidationText> validationTexts)
+            : this((validationTexts ?? throw new System.ArgumentNullException(nameof(validationTexts))).SelectMany(vt => vt._texts).ToArray())
         {
-            if (validationTexts is null)
-            {
-                throw new System.ArgumentNullException(nameof(validationTexts));
-            }
+        }
 
-            foreach (var text in validationTexts)
-            {
-                _texts.AddRange(text._texts);
-            }
+        private ValidationText(string[] texts)
+        {
+            _texts = texts;
         }
 
         /// <summary>
         /// Gets returns the number of elements in the collection.
         /// </summary>
-        public int Count => _texts.Count;
+        public int Count => _texts.Length;
 
         /// <summary>
         /// Indexer.
@@ -59,33 +68,59 @@ namespace ReactiveUI.Validation.Collections
         /// <param name="index">Position.</param>
         public string this[int index] => _texts[index];
 
+        /// <summary>
+        /// Combines multiple <see cref="ValidationText"/> instances into a single instance, or returns <see cref="Empty"/> if the enumeration is empty.
+        /// </summary>
+        /// <param name="validationTexts">An enumeration of <see cref="ValidationText"/>.</param>
+        /// <returns>A <see cref="ValidationText"/>.</returns>
+        public static ValidationText Create(IEnumerable<ValidationText> validationTexts) =>
+            Create(validationTexts.SelectMany(vt => vt._texts).ToArray());
+
+        /// <summary>
+        /// Combines multiple validation messages into a single instance, or returns <see cref="Empty"/> if the enumeration is empty.
+        /// </summary>
+        /// <param name="validationTexts">An enumeration of validation messages.</param>
+        /// <returns>A <see cref="ValidationText"/>.</returns>
+        public static ValidationText Create(IEnumerable<string> validationTexts) => Create(validationTexts.ToArray());
+
+        /// <summary>
+        /// Combines multiple validation messages into a single instance, or returns <see cref="Empty"/> if the enumeration is empty.
+        /// </summary>
+        /// <param name="validationTexts">An array of validation messages.</param>
+        /// <returns>A <see cref="ValidationText"/>.</returns>
+        public static ValidationText Create(params string[] validationTexts) => validationTexts.Length > 0
+            ? new ValidationText(validationTexts)
+            : Empty;
+
         /// <inheritdoc/>
         public IEnumerator<string> GetEnumerator()
         {
-            return _texts.GetEnumerator();
+            return ((IEnumerable<string>)_texts).GetEnumerator();
         }
 
         /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetEnumerator();
+            return _texts.GetEnumerator();
         }
 
         /// <summary>
         /// Adds a text to the collection.
         /// </summary>
         /// <param name="text">Text to be added in the collection.</param>
+        [Obsolete("ValidationText will be made immutable in future versions, please do not use the Add(string) method.")]
         public void Add(string text)
         {
-            _texts.Add(text);
+            _texts = _texts.Concat(new[] { text }).ToArray();
         }
 
         /// <summary>
         /// Clear all texts.
         /// </summary>
+        [Obsolete("ValidationText will be made immutable in future versions, please do not use the Clear() method.")]
         public void Clear()
         {
-            _texts.Clear();
+            _texts = Array.Empty<string>();
         }
 
         /// <summary>

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -26,7 +26,6 @@ namespace ReactiveUI.Validation.Collections
         /// </summary>
         public static readonly ValidationText Empty = new ValidationText(new[] { string.Empty });
 
-        // TODO When Add() & Clear() are obsolesced this should be made read-only.
         private /* readonly */ string[] _texts;
 
         /// <summary>

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -16,9 +16,9 @@ namespace ReactiveUI.Validation.Collections
     public class ValidationText : IEnumerable<string>
     {
         /// <summary>
-        /// The empty validation text singleton instance.
+        /// The empty validation text singleton instance, contains a single empty string.
         /// </summary>
-        public static readonly ValidationText Empty = new ValidationText(Array.Empty<string>());
+        public static readonly ValidationText Empty = new ValidationText(new[] { string.Empty });
 
         // TODO When Add() & Clear() are obsolesced this should be made read-only.
         private /* readonly */ string[] _texts;
@@ -28,7 +28,7 @@ namespace ReactiveUI.Validation.Collections
         /// </summary>
         [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overload instead.")]
         public ValidationText()
-            : this(Array.Empty<string>())
+            : this(Empty._texts)
         {
         }
 
@@ -38,7 +38,7 @@ namespace ReactiveUI.Validation.Collections
         /// <param name="text">Text to be added in the collection.</param>
         [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(string) overload instead.")]
         public ValidationText(string text)
-        :this(new[] { text })
+        : this(new[] { text })
         {
         }
 
@@ -48,13 +48,20 @@ namespace ReactiveUI.Validation.Collections
         /// <param name="validationTexts"><see cref="ValidationText"/> collection to be added into the text collection.</param>
         [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(IEnumerable<ValidationText>) overload instead.")]
         public ValidationText(IEnumerable<ValidationText> validationTexts)
-            : this((validationTexts ?? throw new System.ArgumentNullException(nameof(validationTexts))).SelectMany(vt => vt._texts).ToArray())
+            : this((validationTexts ?? throw new ArgumentNullException(nameof(validationTexts))).SelectMany(vt => vt._texts).ToArray())
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationText"/> class with the array of texts.
+        /// </summary>
+        /// <param name="texts">The array of texts.</param>
         private ValidationText(string[] texts)
         {
-            _texts = texts;
+            // TODO Can remove this check when public constructors are obsolesced as Create method already checks this.
+            _texts = texts.Length < 1 || (texts.Length == 1 && string.IsNullOrEmpty(texts[0]))
+                ? Empty._texts
+                : texts;
         }
 
         /// <summary>
@@ -69,7 +76,7 @@ namespace ReactiveUI.Validation.Collections
         public string this[int index] => _texts[index];
 
         /// <summary>
-        /// Combines multiple <see cref="ValidationText"/> instances into a single instance, or returns <see cref="Empty"/> if the enumeration is empty.
+        /// Combines multiple <see cref="ValidationText"/> instances into a single instance, or returns <see cref="Empty"/> if the enumeration is empty, or contains a single empty element.
         /// </summary>
         /// <param name="validationTexts">An enumeration of <see cref="ValidationText"/>.</param>
         /// <returns>A <see cref="ValidationText"/>.</returns>
@@ -77,20 +84,21 @@ namespace ReactiveUI.Validation.Collections
             Create(validationTexts.SelectMany(vt => vt._texts).ToArray());
 
         /// <summary>
-        /// Combines multiple validation messages into a single instance, or returns <see cref="Empty"/> if the enumeration is empty.
+        /// Combines multiple validation messages into a single instance, or returns <see cref="Empty"/> if the enumeration is empty, or contains a single empty element.
         /// </summary>
         /// <param name="validationTexts">An enumeration of validation messages.</param>
         /// <returns>A <see cref="ValidationText"/>.</returns>
         public static ValidationText Create(IEnumerable<string> validationTexts) => Create(validationTexts.ToArray());
 
         /// <summary>
-        /// Combines multiple validation messages into a single instance, or returns <see cref="Empty"/> if the enumeration is empty.
+        /// Combines multiple validation messages into a single instance, or returns <see cref="Empty"/> if the enumeration is empty, or contains a single empty element.
         /// </summary>
         /// <param name="validationTexts">An array of validation messages.</param>
         /// <returns>A <see cref="ValidationText"/>.</returns>
-        public static ValidationText Create(params string[] validationTexts) => validationTexts.Length > 0
-            ? new ValidationText(validationTexts)
-            : Empty;
+        public static ValidationText Create(params string[] validationTexts) => validationTexts.Length < 1 ||
+            (validationTexts.Length == 1 && string.IsNullOrEmpty(validationTexts[0]))
+                ? Empty
+                : new ValidationText(validationTexts);
 
         /// <inheritdoc/>
         public IEnumerator<string> GetEnumerator()
@@ -120,7 +128,7 @@ namespace ReactiveUI.Validation.Collections
         [Obsolete("ValidationText will be made immutable in future versions, please do not use the Clear() method.")]
         public void Clear()
         {
-            _texts = Array.Empty<string>();
+            _texts = Empty._texts;
         }
 
         /// <summary>

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -18,7 +18,7 @@ namespace ReactiveUI.Validation.Collections
         /// <summary>
         /// The empty validation text singleton instance, contains a single empty string.
         /// </summary>
-        public static readonly ValidationText Empty = new ValidationText(new[] { string.Empty });
+        public static readonly ValidationText Empty = new ValidationText(Array.Empty<string>());
 
         // TODO When Add() & Clear() are obsolesced this should be made read-only.
         private /* readonly */ string[] _texts;
@@ -28,7 +28,7 @@ namespace ReactiveUI.Validation.Collections
         /// </summary>
         [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overload instead.")]
         public ValidationText()
-            : this(Empty._texts)
+            : this(Array.Empty<string>())
         {
         }
 
@@ -58,9 +58,14 @@ namespace ReactiveUI.Validation.Collections
         /// <param name="texts">The array of texts.</param>
         private ValidationText(string[] texts)
         {
+            if (texts is null)
+            {
+                throw new ArgumentNullException(nameof(texts));
+            }
+
             // TODO Can remove this check when public constructors are obsolesced as Create method already checks this.
-            _texts = texts.Length < 1 || (texts.Length == 1 && string.IsNullOrEmpty(texts[0]))
-                ? Empty._texts
+            _texts = texts.Length < 1
+                ? Array.Empty<string>()
                 : texts;
         }
 
@@ -95,8 +100,7 @@ namespace ReactiveUI.Validation.Collections
         /// </summary>
         /// <param name="validationTexts">An array of validation messages.</param>
         /// <returns>A <see cref="ValidationText"/>.</returns>
-        public static ValidationText Create(params string[] validationTexts) => validationTexts.Length < 1 ||
-            (validationTexts.Length == 1 && string.IsNullOrEmpty(validationTexts[0]))
+        public static ValidationText Create(params string[] validationTexts) => validationTexts.Length < 1
                 ? Empty
                 : new ValidationText(validationTexts);
 
@@ -128,7 +132,7 @@ namespace ReactiveUI.Validation.Collections
         [Obsolete("ValidationText will be made immutable in future versions, please do not use the Clear() method.")]
         public void Clear()
         {
-            _texts = Empty._texts;
+            _texts = Array.Empty<string>();
         }
 
         /// <summary>

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -243,7 +243,7 @@ namespace ReactiveUI.Validation.Collections
 
             if (ReferenceEquals(this, None))
             {
-                throw new InvalidOperationException("Adding to ValidationText.None is unsupported.");
+                throw new InvalidOperationException("Clearing ValidationText.None is unsupported.");
             }
 
             _texts = Array.Empty<string>();

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -216,6 +216,16 @@ namespace ReactiveUI.Validation.Collections
         [Obsolete("ValidationText will be made immutable in future versions, please do not use the Add(string) method.")]
         public void Add(string text)
         {
+            if (ReferenceEquals(this, Empty))
+            {
+                throw new InvalidOperationException("Adding to ValidationText.Empty is unsupported.");
+            }
+
+            if (ReferenceEquals(this, None))
+            {
+                throw new InvalidOperationException("Adding to ValidationText.None is unsupported.");
+            }
+
             _texts = _texts.Concat(new[] { text }).ToArray();
         }
 
@@ -226,6 +236,16 @@ namespace ReactiveUI.Validation.Collections
         [Obsolete("ValidationText will be made immutable in future versions, please do not use the Clear() method.")]
         public void Clear()
         {
+            if (ReferenceEquals(this, Empty))
+            {
+                throw new InvalidOperationException("Adding to ValidationText.Empty is unsupported.");
+            }
+
+            if (ReferenceEquals(this, None))
+            {
+                throw new InvalidOperationException("Adding to ValidationText.None is unsupported.");
+            }
+
             _texts = Array.Empty<string>();
         }
 

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace ReactiveUI.Validation.Collections
@@ -26,6 +27,7 @@ namespace ReactiveUI.Validation.Collections
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationText"/> class.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create() overload instead.")]
         public ValidationText()
             : this(Array.Empty<string>())
@@ -36,6 +38,7 @@ namespace ReactiveUI.Validation.Collections
         /// Initializes a new instance of the <see cref="ValidationText"/> class.
         /// </summary>
         /// <param name="text">Text to be added in the collection.</param>
+        [ExcludeFromCodeCoverage]
         [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(string) overload instead.")]
         public ValidationText(string text)
         : this(new[] { text })
@@ -46,6 +49,7 @@ namespace ReactiveUI.Validation.Collections
         /// Initializes a new instance of the <see cref="ValidationText"/> class.
         /// </summary>
         /// <param name="validationTexts"><see cref="ValidationText"/> collection to be added into the text collection.</param>
+        [ExcludeFromCodeCoverage]
         [Obsolete("Calling the constructor is deprecated, please use ValidationText.Create(IEnumerable<ValidationText>) overload instead.")]
         public ValidationText(IEnumerable<ValidationText> validationTexts)
             : this((validationTexts ?? throw new ArgumentNullException(nameof(validationTexts))).SelectMany(vt => vt._texts).ToArray())
@@ -120,6 +124,7 @@ namespace ReactiveUI.Validation.Collections
         /// Adds a text to the collection.
         /// </summary>
         /// <param name="text">Text to be added in the collection.</param>
+        [ExcludeFromCodeCoverage]
         [Obsolete("ValidationText will be made immutable in future versions, please do not use the Add(string) method.")]
         public void Add(string text)
         {
@@ -129,6 +134,7 @@ namespace ReactiveUI.Validation.Collections
         /// <summary>
         /// Clear all texts.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         [Obsolete("ValidationText will be made immutable in future versions, please do not use the Clear() method.")]
         public void Clear()
         {

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -204,9 +204,7 @@ namespace ReactiveUI.Validation.Components
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             Func<TViewModelProperty, bool> isValidFunc,
             string message)
-            : this(viewModel, viewModelProperty, isValidFunc, (p, v) => new ValidationText(v
-                ? string.Empty
-                : message))
+            : this(viewModel, viewModelProperty, isValidFunc, (p, v) => v ? ValidationText.Empty : ValidationText.Create(message))
         {
         }
 
@@ -222,9 +220,8 @@ namespace ReactiveUI.Validation.Components
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             Func<TViewModelProperty, bool> isValidFunc,
             Func<TViewModelProperty, string> message)
-            : this(viewModel, viewModelProperty, isValidFunc, (p, v) => new ValidationText(v
-                ? string.Empty
-                : message(p)))
+            : this(viewModel, viewModelProperty, isValidFunc, (p, v) =>
+                v ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 
@@ -241,7 +238,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModelProperty, bool> isValidFunc,
             Func<TViewModelProperty, bool, string> messageFunc)
             : this(viewModel, viewModelProperty, isValidFunc, (prop1, isValid) =>
-                new ValidationText(messageFunc(prop1, isValid)))
+                ValidationText.Create(messageFunc(prop1, isValid)))
         {
         }
 

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -221,7 +221,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModelProperty, bool> isValidFunc,
             Func<TViewModelProperty, string> message)
             : this(viewModel, viewModelProperty, isValidFunc, (p, v) =>
-                v ? ValidationText.Empty : ValidationText.Create(message(p)))
+                v ? ValidationText.None : ValidationText.Create(message(p)))
         {
         }
 

--- a/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
@@ -47,7 +47,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModel, IObservable<bool>> validityObservable,
             string message)
             : this(viewModel, viewModelProperty, validityObservable, (p, isValid) =>
-                new ValidationText(isValid ? string.Empty : message))
+                isValid ? ValidationText.Empty : ValidationText.Create(message))
         {
         }
 
@@ -64,7 +64,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModel, IObservable<bool>> validityObservable,
             Func<TViewModel, string> message)
             : this(viewModel, viewModelProperty, validityObservable, (p, isValid) =>
-                new ValidationText(isValid ? string.Empty : message(p)))
+                isValid ? ValidationText.Empty : ValidationText.Create(message(p))))
         {
         }
 
@@ -81,7 +81,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModel, IObservable<bool>> validityObservable,
             Func<TViewModel, bool, string> messageFunc)
             : this(viewModel, viewModelProperty, validityObservable, (vm, state) =>
-                new ValidationText(messageFunc(vm, state)))
+                ValidationText.Create(messageFunc(vm, state)))
         {
         }
 
@@ -129,7 +129,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModel, IObservable<bool>> validityObservable,
             string message)
             : this(viewModel, validityObservable, (p, isValid) =>
-                new ValidationText(isValid ? string.Empty : message))
+                isValid ? ValidationText.Empty : ValidationText.Create(message))
         {
         }
 
@@ -144,7 +144,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModel, IObservable<bool>> validityObservable,
             Func<TViewModel, string> message)
             : this(viewModel, validityObservable, (p, isValid) =>
-                new ValidationText(isValid ? string.Empty : message(p)))
+                isValid ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 
@@ -158,7 +158,7 @@ namespace ReactiveUI.Validation.Components
             TViewModel viewModel,
             Func<TViewModel, IObservable<bool>> validityObservable,
             Func<TViewModel, bool, string> messageFunc)
-            : this(viewModel, validityObservable, (vm, state) => new ValidationText(messageFunc(vm, state)))
+            : this(viewModel, validityObservable, (vm, state) => ValidationText.Create(messageFunc(vm, state)))
         {
         }
 

--- a/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ModelObservableValidation.cs
@@ -64,7 +64,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModel, IObservable<bool>> validityObservable,
             Func<TViewModel, string> message)
             : this(viewModel, viewModelProperty, validityObservable, (p, isValid) =>
-                isValid ? ValidationText.Empty : ValidationText.Create(message(p))))
+                isValid ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 

--- a/src/ReactiveUI.Validation/Components/ObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation.cs
@@ -116,7 +116,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModel, TValue, bool> isValidFunc,
             Func<TViewModel, TValue, bool, string> messageFunc)
             : base(viewModel, observable, isValidFunc, (vm, value, isValid) =>
-                new ValidationText(messageFunc(vm, value, isValid))) =>
+                ValidationText.Create(messageFunc(vm, value, isValid))) =>
             AddProperty(viewModelProperty);
 
         /// <summary>
@@ -217,7 +217,7 @@ namespace ReactiveUI.Validation.Components
             Func<TViewModel, TValue, bool> isValidFunc,
             Func<TViewModel, TValue, bool, string> messageFunc)
             : base(viewModel, observable, isValidFunc, (vm, value, isValid) =>
-                new ValidationText(messageFunc(vm, value, isValid)))
+                ValidationText.Create(messageFunc(vm, value, isValid)))
         {
         }
 

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -82,7 +82,7 @@ namespace ReactiveUI.Validation.Contexts
             _validationText = _validSubject
                 .StartWith(true)
                 .Select(_ => BuildText())
-                .ToProperty(this, m => m.Text, new ValidationText(), scheduler: scheduler)
+                .ToProperty(this, m => m.Text, ValidationText.Empty, scheduler: scheduler)
                 .DisposeWith(_disposables);
 
             _validSubject
@@ -219,7 +219,7 @@ namespace ReactiveUI.Validation.Contexts
         /// Returns the <see cref="ValidationText"/> with all the error messages from the non valid components.
         /// </returns>
         private ValidationText BuildText() =>
-            new ValidationText(_validations
+            ValidationText.Create(_validations
                 .Where(p => !p.IsValid && p.Text != null)
                 .Select(p => p.Text!));
     }

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -82,7 +82,7 @@ namespace ReactiveUI.Validation.Contexts
             _validationText = _validSubject
                 .StartWith(true)
                 .Select(_ => BuildText())
-                .ToProperty(this, m => m.Text, ValidationText.Empty, scheduler: scheduler)
+                .ToProperty(this, m => m.Text, ValidationText.None, scheduler: scheduler)
                 .DisposeWith(_disposables);
 
             _validSubject

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -91,11 +91,11 @@ namespace ReactiveUI.Validation.Helpers
         public virtual IEnumerable GetErrors(string propertyName) =>
             string.IsNullOrEmpty(propertyName) ?
                 SelectInvalidPropertyValidations()
-                    .SelectMany(validation => validation.Text ?? ValidationText.Empty)
+                    .SelectMany(validation => validation.Text ?? ValidationText.None)
                     .ToArray() :
                 SelectInvalidPropertyValidations()
                     .Where(validation => validation.ContainsPropertyName(propertyName))
-                    .SelectMany(validation => validation.Text ?? ValidationText.Empty)
+                    .SelectMany(validation => validation.Text ?? ValidationText.None)
                     .ToArray();
 
         /// <summary>

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -14,6 +14,7 @@ using System.Reactive.Linq;
 using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI.Validation.Abstractions;
+using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.Contexts;
 using ReactiveUI.Validation.States;
@@ -90,11 +91,11 @@ namespace ReactiveUI.Validation.Helpers
         public virtual IEnumerable GetErrors(string propertyName) =>
             string.IsNullOrEmpty(propertyName) ?
                 SelectInvalidPropertyValidations()
-                    .SelectMany(validation => validation.Text)
+                    .SelectMany(validation => validation.Text ?? ValidationText.Empty)
                     .ToArray() :
                 SelectInvalidPropertyValidations()
                     .Where(validation => validation.ContainsPropertyName(propertyName))
-                    .SelectMany(validation => validation.Text)
+                    .SelectMany(validation => validation.Text ?? ValidationText.Empty)
                     .ToArray();
 
         /// <summary>

--- a/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
+++ b/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;uap10.0.17763</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
+++ b/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;uap10.0.17763</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
+++ b/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;uap10.0.17763</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
+++ b/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;uap10.0.17763</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/src/ReactiveUI.Validation/States/ValidationState.cs
+++ b/src/ReactiveUI.Validation/States/ValidationState.cs
@@ -26,7 +26,7 @@ namespace ReactiveUI.Validation.States
         /// <param name="isValid">Determines if the property is valid or not.</param>
         /// <param name="text">Validation text.</param>
         public ValidationState(bool isValid, string text)
-            : this(isValid, new ValidationText(text))
+            : this(isValid, ValidationText.Create(text))
         {
         }
 
@@ -50,7 +50,7 @@ namespace ReactiveUI.Validation.States
         [ExcludeFromCodeCoverage]
         [Obsolete("This constructor overload is going to be removed soon.")]
         public ValidationState(bool isValid, string text, IValidationComponent component)
-            : this(isValid, new ValidationText(text), component)
+            : this(isValid, ValidationText.Create(text), component)
         {
         }
 

--- a/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.cs
+++ b/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.cs
@@ -59,14 +59,16 @@ namespace ReactiveUI.Validation.TemplateGenerators
         /// </summary>
         private bool _connected;
 
-        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Generated dynamically with template.")]
+        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented",
+            Justification = "Generated dynamically with template.")]
         public BasePropertyValidation(
             TViewModel viewModel,
             Expression<Func<TViewModel, TProperty1>> property1,
             Expression<Func<TViewModel, TProperty2>> property2,
             Func<(TProperty1, TProperty2), bool> isValidFunc,
             Func<(TProperty1, TProperty2), string> message)
-            : this(viewModel, property1, property2, isValidFunc, (p, v) => new ValidationText(v ? string.Empty : message(p)))
+            : this(viewModel, property1, property2, isValidFunc,
+                (p, v) => v ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 
@@ -77,7 +79,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
             Expression<Func<TViewModel, TProperty2>> property2,
             Func<(TProperty1, TProperty2), bool> isValidFunc,
             Func<(TProperty1, TProperty2), bool, string> messageFunc)
-            : this(viewModel, property1, property2, isValidFunc, (p, v) => new ValidationText(messageFunc(p, v)))
+            : this(viewModel, property1, property2, isValidFunc, (p, v) => ValidationText.Create(messageFunc(p, v)))
         {
         }
 
@@ -204,7 +206,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
             Expression<Func<TViewModel, TProperty3>> property3,
             Func<(TProperty1, TProperty2, TProperty3), bool> isValidFunc,
             Func<(TProperty1, TProperty2, TProperty3), string> message)
-            : this(viewModel, property1, property2, property3, isValidFunc, (p, v) => new ValidationText(v ? string.Empty : message(p)))
+            : this(viewModel, property1, property2, property3, isValidFunc, (p, v) => v ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 
@@ -216,7 +218,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
             Expression<Func<TViewModel, TProperty3>> property3,
             Func<(TProperty1, TProperty2, TProperty3), bool> isValidFunc,
             Func<(TProperty1, TProperty2, TProperty3), bool, string> messageFunc)
-            : this(viewModel, property1, property2, property3, isValidFunc, (p, v) => new ValidationText(messageFunc(p, v)))
+            : this(viewModel, property1, property2, property3, isValidFunc, (p, v) => ValidationText.Create(messageFunc(p, v)))
         {
         }
 
@@ -351,7 +353,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
             Expression<Func<TViewModel, TProperty4>> property4,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4), bool> isValidFunc,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4), string> message)
-            : this(viewModel, property1, property2, property3, property4, isValidFunc, (p, v) => new ValidationText(v ? string.Empty : message(p)))
+            : this(viewModel, property1, property2, property3, property4, isValidFunc, (p, v) => v ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 
@@ -364,7 +366,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
             Expression<Func<TViewModel, TProperty4>> property4,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4), bool> isValidFunc,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4), bool, string> messageFunc)
-            : this(viewModel, property1, property2, property3, property4, isValidFunc, (p, v) => new ValidationText(messageFunc(p, v)))
+            : this(viewModel, property1, property2, property3, property4, isValidFunc, (p, v) => ValidationText.Create(messageFunc(p, v)))
         {
         }
 
@@ -507,7 +509,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
             Expression<Func<TViewModel, TProperty5>> property5,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4, TProperty5), bool> isValidFunc,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4, TProperty5), string> message)
-            : this(viewModel, property1, property2, property3, property4, property5, isValidFunc, (p, v) => new ValidationText(v ? string.Empty : message(p)))
+            : this(viewModel, property1, property2, property3, property4, property5, isValidFunc, (p, v) => v ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 
@@ -521,7 +523,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
             Expression<Func<TViewModel, TProperty5>> property5,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4, TProperty5), bool> isValidFunc,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4, TProperty5), bool, string> messageFunc)
-            : this(viewModel, property1, property2, property3, property4, property5, isValidFunc, (p, v) => new ValidationText(messageFunc(p, v)))
+            : this(viewModel, property1, property2, property3, property4, property5, isValidFunc, (p, v) => ValidationText.Create(messageFunc(p, v)))
         {
         }
 
@@ -672,7 +674,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
             Expression<Func<TViewModel, TProperty6>> property6,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6), bool> isValidFunc,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6), string> message)
-            : this(viewModel, property1, property2, property3, property4, property5, property6, isValidFunc, (p, v) => new ValidationText(v ? string.Empty : message(p)))
+            : this(viewModel, property1, property2, property3, property4, property5, property6, isValidFunc, (p, v) => v ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 
@@ -687,7 +689,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
             Expression<Func<TViewModel, TProperty6>> property6,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6), bool> isValidFunc,
             Func<(TProperty1, TProperty2, TProperty3, TProperty4, TProperty5, TProperty6), bool, string> messageFunc)
-            : this(viewModel, property1, property2, property3, property4, property5, property6, isValidFunc, (p, v) => new ValidationText(messageFunc(p, v)))
+            : this(viewModel, property1, property2, property3, property4, property5, property6, isValidFunc, (p, v) => ValidationText.Create(messageFunc(p, v)))
         {
         }
 

--- a/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.cs
+++ b/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.cs
@@ -59,16 +59,14 @@ namespace ReactiveUI.Validation.TemplateGenerators
         /// </summary>
         private bool _connected;
 
-        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented",
-            Justification = "Generated dynamically with template.")]
+        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Generated dynamically with template.")]
         public BasePropertyValidation(
             TViewModel viewModel,
             Expression<Func<TViewModel, TProperty1>> property1,
             Expression<Func<TViewModel, TProperty2>> property2,
             Func<(TProperty1, TProperty2), bool> isValidFunc,
             Func<(TProperty1, TProperty2), string> message)
-            : this(viewModel, property1, property2, isValidFunc,
-                (p, v) => v ? ValidationText.Empty : ValidationText.Create(message(p)))
+            : this(viewModel, property1, property2, isValidFunc, (p, v) => v ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 

--- a/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.tt
+++ b/src/ReactiveUI.Validation/TemplateGenerators/PropertyValidationGenerator.tt
@@ -77,7 +77,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
     <# } #>
         Func<(<#=String.Join(", ",templParams)#>), bool> isValidFunc,<#Write("\r\n");#>
             Func<(<#=String.Join(", ",templParams)#>), string> message)
-            : this(viewModel, <#=String.Join(", ",valuePropertyParams)#>, isValidFunc, (p, v) => new ValidationText(v ? string.Empty : message(p)))
+            : this(viewModel, <#=String.Join(", ",valuePropertyParams)#>, isValidFunc, (p, v) => v ? ValidationText.Empty : ValidationText.Create(message(p)))
         {
         }
 
@@ -89,7 +89,7 @@ namespace ReactiveUI.Validation.TemplateGenerators
     <# } #>
         Func<(<#=String.Join(", ",templParams) #>), bool> isValidFunc,
             Func<(<#=String.Join(", ",templParams)#>), bool, string> messageFunc)
-            : this(viewModel, <#=String.Join(", ",valuePropertyParams)#>, isValidFunc, (p, v) => new ValidationText(messageFunc(p, v)))
+            : this(viewModel, <#=String.Join(", ",valuePropertyParams)#>, isValidFunc, (p, v) => ValidationText.Create(messageFunc(p, v)))
         {
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This pull request fixes #142 and implements #141.  There is no good reason for `ValidationText` to be mutable, as the current mutators (`Add` and `Clear`) are not used by the library and introduce potential thread-safety issues when validating asynchronously.

**What is the current behavior?**
#142 describes a bug based on the nullability of `ReactiveValidationObject.SelectInvalidPropertyValidations`, the fix is included in this PR as it is dependent on changes implemented for #141

#141 describes the benefits of making `ValidationText` immutable.  As well as thread-safety, we can provide the `ValidationText.Empty` and `ValidationText.None` singletons for improved performance and memory utilisation.  The current behaviour creates a lot of unnecessary lists.


**What is the new behavior?**
This PR introduces a pseudo-immutable version of `ValidationText` which exposes new `Create` factory methods.  The factory methods will automatically detect a `None` or `Empty` equivalent and return the new corresponding singleton instead of a new instance, reducing memory utilisation.

The underlying `List<string>` is replaced with a `string[]` to improve performance and memory utilisation.

Currently, the underlying array is not `readonly` as the `Add()` and `Clear()` mutators (now marked as obsolete) are implemented for backwards compatibility.  Using those methods will break thread-safety (which is not a breaking change).  If those methods are not used, the class is thread-safe.  

The existing constructors are marked as obsolete to encourage adoption of the factory methods.  

TODO comments are included for changes that can be made when the existing constructors/methods are finally removed in future.

**What might this PR break?**
The provided implementation should be backwards compatible, it marks certain methods/constructors obsolete which will produce warnings in consumers.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:
Existing usages of the now obsolete constructors have been removed in the library and replaced with calls to the factory methods.  As such these frequently return one of the new singletons.  Trying to call `Add()` or `Clear()` on the singletons results in an `InvalidOperationException` to prevent more serious bugs.

Where consumers created their own `ValidationText` instances this is not a problem, as the singletons will not be in use in existing code.  However, attempting to modify `ValidationText` instances provided by the library itself may result in the new exception.  This is considered unlikely in practice.