### PR TITLE
housekeeping: Correct ValidationText Error Message

### DIFF
--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -237,7 +237,7 @@ namespace ReactiveUI.Validation.Collections
         {
             if (ReferenceEquals(this, Empty))
             {
-                throw new InvalidOperationException("Adding to ValidationText.Empty is unsupported.");
+                throw new InvalidOperationException("Clearing ValidationText.Empty is unsupported.");
             }
 
             if (ReferenceEquals(this, None))


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR corrects the `ValidationText` error message. Guessing the message was accidentally made as misleading. Also, in the scope of this PR, we are intending to use the opportunity to ship a new `1.8.x` build to NuGet.