### PR TITLE
feature: Allow the ViewModel to be Null in BindValidation

### DIFF
--- a/src/ReactiveUI.Validation.AndroidSupport/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation.AndroidSupport/Extensions/ViewForExtensions.cs
@@ -30,7 +30,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
         /// <typeparam name="TViewModelProperty">ViewModel property type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
@@ -42,7 +42,7 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidation<TView, TViewModel, TViewModelProperty>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             TextInputLayout viewProperty,
             IValidationTextFormatter<string>? formatter = null)
@@ -67,7 +67,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
         /// <typeparam name="TViewModelProperty">ViewModel property type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
@@ -81,7 +81,7 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             TextInputLayout viewProperty,
             IValidationTextFormatter<string>? formatter = null)
@@ -104,7 +104,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TView">IViewFor of TViewModel.</typeparam>
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewModelHelperProperty">ViewModel's ValidationHelper property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
@@ -116,7 +116,7 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidation<TView, TViewModel>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel?, ValidationHelper>> viewModelHelperProperty,
             TextInputLayout viewProperty,
             IValidationTextFormatter<string>? formatter = null)

--- a/src/ReactiveUI.Validation.AndroidSupport/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation.AndroidSupport/Extensions/ViewForExtensions.cs
@@ -15,6 +15,7 @@ using ReactiveUI.Validation.Helpers;
 using ReactiveUI.Validation.ValidationBindings;
 using Splat;
 
+// ReSharper disable once CheckNamespace
 namespace ReactiveUI.Validation.Extensions
 {
     /// <summary>
@@ -49,6 +50,21 @@ namespace ReactiveUI.Validation.Extensions
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
+            if (view is null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            if (viewModelProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewModelProperty));
+            }
+
+            if (viewProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewProperty));
+            }
+
             formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
                           SingleLineFormatter.Default;
 
@@ -88,6 +104,21 @@ namespace ReactiveUI.Validation.Extensions
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
+            if (view is null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            if (viewModelProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewModelProperty));
+            }
+
+            if (viewProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewProperty));
+            }
+
             formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
                           SingleLineFormatter.Default;
 
@@ -123,6 +154,21 @@ namespace ReactiveUI.Validation.Extensions
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
+            if (view is null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            if (viewModelHelperProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewModelHelperProperty));
+            }
+
+            if (viewProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewProperty));
+            }
+
             formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
                           SingleLineFormatter.Default;
 

--- a/src/ReactiveUI.Validation.AndroidX/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation.AndroidX/Extensions/ViewForExtensions.cs
@@ -30,7 +30,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
         /// <typeparam name="TViewModelProperty">ViewModel property type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
@@ -42,7 +42,7 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidation<TView, TViewModel, TViewModelProperty>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             TextInputLayout viewProperty,
             IValidationTextFormatter<string>? formatter = null)
@@ -67,7 +67,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
         /// <typeparam name="TViewModelProperty">ViewModel property type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
@@ -81,7 +81,7 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             TextInputLayout viewProperty,
             IValidationTextFormatter<string>? formatter = null)
@@ -104,7 +104,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TView">IViewFor of TViewModel.</typeparam>
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewModelHelperProperty">ViewModel's ValidationHelper property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
@@ -116,7 +116,7 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution.")]
         public static IDisposable BindValidation<TView, TViewModel>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel?, ValidationHelper>> viewModelHelperProperty,
             TextInputLayout viewProperty,
             IValidationTextFormatter<string>? formatter = null)

--- a/src/ReactiveUI.Validation.AndroidX/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation.AndroidX/Extensions/ViewForExtensions.cs
@@ -15,6 +15,7 @@ using ReactiveUI.Validation.Helpers;
 using ReactiveUI.Validation.ValidationBindings;
 using Splat;
 
+// ReSharper disable once CheckNamespace
 namespace ReactiveUI.Validation.Extensions
 {
     /// <summary>
@@ -49,6 +50,21 @@ namespace ReactiveUI.Validation.Extensions
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
+            if (view is null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            if (viewModelProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewModelProperty));
+            }
+
+            if (viewProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewProperty));
+            }
+
             formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
                           SingleLineFormatter.Default;
 
@@ -88,6 +104,21 @@ namespace ReactiveUI.Validation.Extensions
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
+            if (view is null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            if (viewModelProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewModelProperty));
+            }
+
+            if (viewProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewProperty));
+            }
+
             formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
                           SingleLineFormatter.Default;
 
@@ -123,6 +154,21 @@ namespace ReactiveUI.Validation.Extensions
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
+            if (view is null)
+            {
+                throw new ArgumentNullException(nameof(view));
+            }
+
+            if (viewModelHelperProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewModelHelperProperty));
+            }
+
+            if (viewProperty is null)
+            {
+                throw new ArgumentNullException(nameof(viewProperty));
+            }
+
             formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
                           SingleLineFormatter.Default;
 

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -284,19 +284,19 @@ namespace ReactiveUI.Validation.Extensions
         [System.Obsolete("This method is a part of ReactiveUI internals and will be removed from ReactiveUI" +
             ".Validation public API soon.")]
         public static System.IDisposable BindToDirect<TTarget, TValue>(System.IObservable<TValue> @this, TTarget target, System.Linq.Expressions.Expression viewExpression) { }
-        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
-        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
-        public static System.IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+        public static System.IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("This method is no longer required, BindValidation now supports multiple validatio" +
             "ns.")]
-        public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+        public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -284,19 +284,19 @@ namespace ReactiveUI.Validation.Extensions
         [System.Obsolete("This method is a part of ReactiveUI internals and will be removed from ReactiveUI" +
             ".Validation public API soon.")]
         public static System.IDisposable BindToDirect<TTarget, TValue>(System.IObservable<TValue> @this, TTarget target, System.Linq.Expressions.Expression viewExpression) { }
-        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
-        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
-        public static System.IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+        public static System.IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [System.Obsolete("This method is no longer required, BindValidation now supports multiple validatio" +
             "ns.")]
-        public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+        public static System.IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
             where TView : ReactiveUI.IViewFor<TViewModel>
             where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
     }

--- a/src/ReactiveUI.Validation.Tests/Models/TestView.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/TestView.cs
@@ -8,8 +8,17 @@ namespace ReactiveUI.Validation.Tests.Models
     /// <summary>
     /// Mocked View.
     /// </summary>
-    public class TestView : IViewFor<TestViewModel>
+    public class TestView : ReactiveObject, IViewFor<TestViewModel>
     {
+        private TestViewModel _viewModel;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestView"/> class.
+        /// </summary>
+        public TestView()
+        {
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TestView"/> class.
         /// </summary>
@@ -27,7 +36,11 @@ namespace ReactiveUI.Validation.Tests.Models
         }
 
         /// <inheritdoc/>
-        public TestViewModel ViewModel { get; set; }
+        public TestViewModel ViewModel
+        {
+            get => _viewModel;
+            set => this.RaiseAndSetIfChanged(ref _viewModel, value);
+        }
 
         /// <summary>
         /// Gets or sets the Name Label which emulates a Text property (eg. Entry in Xamarin.Forms).

--- a/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
+++ b/src/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
@@ -749,6 +749,36 @@ namespace ReactiveUI.Validation.Tests
             Assert.DoesNotContain(viewModelIsBlockedMessage, view.NameErrorContainer.Text, comparison);
         }
 
+        /// <summary>
+        /// Verifies that we support nullable view model properties.
+        /// </summary>
+        [Fact]
+        public void ShouldSupportDelayedViewModelInitialization()
+        {
+            var view = new TestView
+            {
+                NameErrorLabel = string.Empty,
+                NameErrorContainer = { Text = string.Empty }
+            };
+
+            view.Bind(view.ViewModel, x => x.Name, x => x.NameLabel);
+            view.BindValidation(view.ViewModel, x => x.Name, x => x.NameErrorLabel);
+            view.BindValidation(view.ViewModel, x => x.NameErrorContainer.Text);
+
+            Assert.Empty(view.NameErrorLabel);
+            Assert.Empty(view.NameErrorContainer.Text);
+
+            const string errorMessage = "Name shouldn't be empty.";
+            var viewModel = new TestViewModel();
+            viewModel.ValidationRule(x => x.Name, x => !string.IsNullOrWhiteSpace(x), errorMessage);
+            view.ViewModel = viewModel;
+
+            Assert.NotEmpty(view.NameErrorLabel);
+            Assert.NotEmpty(view.NameErrorContainer.Text);
+            Assert.Equal(errorMessage, view.NameErrorLabel);
+            Assert.Equal(errorMessage, view.NameErrorContainer.Text);
+        }
+
         private class CustomValidationState : IValidationState
         {
             public CustomValidationState(bool isValid, string message)

--- a/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
@@ -31,7 +31,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TViewModelProperty">ViewModel property type.</typeparam>
         /// <typeparam name="TViewProperty">View property type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
@@ -45,18 +45,13 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution")]
         public static IDisposable BindValidationEx<TView, TViewModel, TViewModelProperty, TViewProperty>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
-            if (viewModel is null)
-            {
-                throw new ArgumentNullException(nameof(viewModel));
-            }
-
             if (viewModelProperty is null)
             {
                 throw new ArgumentNullException(nameof(viewModelProperty));
@@ -78,7 +73,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TViewModelProperty">ViewModel property type.</typeparam>
         /// <typeparam name="TViewProperty">View property type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewModelProperty">ViewModel property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
@@ -90,18 +85,13 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution")]
         public static IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel, TViewModelProperty>> viewModelProperty,
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
-            if (viewModel is null)
-            {
-                throw new ArgumentNullException(nameof(viewModel));
-            }
-
             if (viewModelProperty is null)
             {
                 throw new ArgumentNullException(nameof(viewModelProperty));
@@ -122,7 +112,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
         /// <typeparam name="TViewProperty">View property type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
         /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global
@@ -133,17 +123,12 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution")]
         public static IDisposable BindValidation<TView, TViewModel, TViewProperty>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
-            if (viewModel is null)
-            {
-                throw new ArgumentNullException(nameof(viewModel));
-            }
-
             if (viewProperty is null)
             {
                 throw new ArgumentNullException(nameof(viewProperty));
@@ -159,7 +144,7 @@ namespace ReactiveUI.Validation.Extensions
         /// <typeparam name="TViewModel">ViewModel type.</typeparam>
         /// <typeparam name="TViewProperty">View property type.</typeparam>
         /// <param name="view">IViewFor instance.</param>
-        /// <param name="viewModel">ViewModel instance.</param>
+        /// <param name="viewModel">ViewModel instance. Can be null, used for generic type resolution.</param>
         /// <param name="viewModelHelperProperty">ViewModel's ValidationHelper property.</param>
         /// <param name="viewProperty">View property to bind the validation message.</param>
         /// <param name="formatter">
@@ -171,18 +156,13 @@ namespace ReactiveUI.Validation.Extensions
         [SuppressMessage("Design", "CA1801: Parameter unused", Justification = "Used for generic resolution")]
         public static IDisposable BindValidation<TView, TViewModel, TViewProperty>(
             this TView view,
-            TViewModel viewModel,
+            TViewModel? viewModel,
             Expression<Func<TViewModel?, ValidationHelper>> viewModelHelperProperty,
             Expression<Func<TView, TViewProperty>> viewProperty,
             IValidationTextFormatter<string>? formatter = null)
             where TView : IViewFor<TViewModel>
             where TViewModel : class, IReactiveObject, IValidatableViewModel
         {
-            if (viewModel is null)
-            {
-                throw new ArgumentNullException(nameof(viewModel));
-            }
-
             if (viewModelHelperProperty is null)
             {
                 throw new ArgumentNullException(nameof(viewModelHelperProperty));


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR changes our nullability annotations to allow passing null view models to `BindValidation`. This could be potentially useful in cases when the view model is initialized after the control is activated, or when a view model is replaced with another view model after activation etc.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, we don't use the `viewModel` parameter in `BindValidation`, but check if it is `null` and throw `ANE` if it is null.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, we support delayed view model initialization and just don't throw when `BindValidation` is called.

**What might this PR break?**

Nothing.