### PR TITLE
feature: Custom Formatters in ReactiveValidationObject

### DIFF
--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -321,7 +321,7 @@ namespace ReactiveUI.Validation.Helpers
 {
     public abstract class ReactiveValidationObject : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo
     {
-        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
         public bool HasErrors { get; }
         public ReactiveUI.Validation.Contexts.ValidationContext ValidationContext { get; }
         public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs>? ErrorsChanged;
@@ -333,7 +333,7 @@ namespace ReactiveUI.Validation.Helpers
         "veValidationObject.")]
     public abstract class ReactiveValidationObject<TViewModel> : ReactiveUI.Validation.Helpers.ReactiveValidationObject
     {
-        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
     }
     public class ValidationHelper : ReactiveUI.ReactiveObject, System.IDisposable
     {

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -321,7 +321,7 @@ namespace ReactiveUI.Validation.Helpers
 {
     public abstract class ReactiveValidationObject : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo
     {
-        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
         public bool HasErrors { get; }
         public ReactiveUI.Validation.Contexts.ValidationContext ValidationContext { get; }
         public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs>? ErrorsChanged;
@@ -333,7 +333,7 @@ namespace ReactiveUI.Validation.Helpers
         "veValidationObject.")]
     public abstract class ReactiveValidationObject<TViewModel> : ReactiveUI.Validation.Helpers.ReactiveValidationObject
     {
-        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
     }
     public class ValidationHelper : ReactiveUI.ReactiveObject, System.IDisposable
     {

--- a/src/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
+++ b/src/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
@@ -4,6 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Reactive.Concurrency;
+using ReactiveUI.Validation.Formatters.Abstractions;
 using ReactiveUI.Validation.Helpers;
 
 namespace ReactiveUI.Validation.Tests.Models
@@ -21,6 +22,15 @@ namespace ReactiveUI.Validation.Tests.Models
         /// </summary>
         public IndeiTestViewModel()
             : base(ImmediateScheduler.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IndeiTestViewModel"/> class.
+        /// </summary>
+        /// <param name="formatter">Validation text formatter.</param>
+        public IndeiTestViewModel(IValidationTextFormatter<string> formatter)
+            : base(ImmediateScheduler.Instance, formatter)
         {
         }
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Currently, our `INotifyDataErrorInfo` implementation doesn't support custom formatters. The support for custom validation text formatters might be useful in cases when one needs to implement localization in their application via passing resource keys to `ValidationRule` calls instead of validation messages.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, there is no way to customize messages emitted by `INotifyDataErrorInfo`.

**What is the new behavior?**
<!-- If this is a feature change -->

Now, in order to customize the messages emitted by `INotifyDataErrorInfo`, one needs to either pass an instance of a custom `IValidationTextFormatter<string>` to `ReactiveValidationObject` constructor, or to register a default `IValidationTextFormatter<string>` globally via `Locator.Current.RegisterConstant`, as documented in https://github.com/reactiveui/ReactiveUI.Validation/pull/153

**What might this PR break?**

Nothing, this change shouldn't be breaking.
