### PR TITLE
housekeeping: Use coverlet-msbuild GitHub Action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
-        
+
     - name: NBGV
       id: nbgv
       uses: dotnet/nbgv@master
@@ -41,7 +41,7 @@ jobs:
     - name: NuGet Restore
       run: dotnet restore
       working-directory: src
-      
+
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1
 
@@ -49,29 +49,38 @@ jobs:
       run: msbuild /t:build,pack /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=${{ env.configuration }}
       working-directory: src
 
-    - name: Install Report Generator
-      run: dotnet tool install --global dotnet-reportgenerator-globaltool
+    - name: Run Unit Tests and Generate Coverage
+      uses: glennawatson/coverlet-msbuild@v1
+      with:
+        project-files: 'src/**/*Tests*.csproj'
+        no-build: true
+        exclude-filter: '[${{env.productNamespacePrefix}}*Tests.*]*'
+        include-filter: '[${{env.productNamespacePrefix}}*]*'
+        output-format: cobertura
+        output: '../../artifacts/coverage/'
+        configuration: ${{ env.configuration }}
+        skip-auto-props: false
+        use-sourcelink: true
+        working-directory: src
 
-    - name: Run Unit Tests
-      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput="../../artifacts/coverage/coverage.xml" /p:Include="[${{ env.productNamespacePrefix}}*]*" /p:Exclude="[${{ env.productNamespacePrefix}}*Tests.*]*"
-      working-directory: src
-
-    - name: Generate Coverage Report
-      run: reportgenerator -reports:"coverage.*.xml" -targetdir:report-output
-      working-directory: artifacts/coverage
+    - name: Combine Coverage Reports
+      shell: bash
+      run: |
+        dotnet tool install --global dotnet-reportgenerator-globaltool
+        reportgenerator -reports:artifacts/coverage/*.xml -targetdir:artifacts/finalcoverage -reporttypes:Cobertura
 
     - name: Upload Code Coverage
       run: |
         npm install -g codecov
-        codecov
-      working-directory: artifacts/coverage
+        codecov --file=artifacts/finalcoverage/Cobertura.xml
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
     - name: Create NuGet Artifacts
       uses: actions/upload-artifact@master
       with:
         name: nuget
-        path: '**/*.nupkg'
+        path: 'artifacts/finalcoverage' # '**/*.nupkg'
 
   release:
     runs-on: ubuntu-latest
@@ -124,4 +133,3 @@ jobs:
         SOURCE_URL: https://api.nuget.org/v3/index.json
       run: |
         dotnet nuget push -s ${{ env.SOURCE_URL }} -k ${{ env.NUGET_AUTH_TOKEN }} **/*.nupkg
-

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -58,7 +58,6 @@ jobs:
         include-filter: '[${{env.productNamespacePrefix}}*]*'
         output-format: cobertura
         output: '../../artifacts/coverage/'
-        configuration: ${{ env.configuration }}
         skip-auto-props: false
         use-sourcelink: true
         working-directory: src


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

We are using [glennawatson/coverlet-msbuild@v1](https://github.com/glennawatson/coverlet-msbuild) based on [Fusillade](https://github.com/reactiveui/fusillade) config for ReactiveUI.Validation CI now.