### PR TITLE
housekeeping: Clean NuGet Locals before CI Build

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -44,7 +44,7 @@ jobs:
 
     # The workaround from https://github.com/actions/setup-dotnet/issues/155#issuecomment-748452076
     - name: Clean
-      run: msbuild LoginApp.sln /t:clean /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration && dotnet nuget locals all --clear
+      run: msbuild LoginApp.sln /t:clean /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration && dotnet nuget locals all --clear
       working-directory: samples
       env:
         Configuration: ${{ matrix.configuration }}

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -36,6 +36,10 @@ jobs:
       with:
         dotnet-version: 5.0.x
 
+    # The workaround from https://github.com/actions/setup-dotnet/issues/155#issuecomment-748452076
+    - name: Clean
+      run: msbuild LoginApp.sln /t:clean /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration && dotnet nuget locals all --clear
+
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -5,10 +5,12 @@ on:
     branches: [ main ]
     paths:
       - 'samples/**'
+      - '.github/**'
   pull_request:
     branches: [ main ]
     paths:
       - 'samples/**'
+      - '.github/**'
 
 jobs:
   build-samples:

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -45,6 +45,9 @@ jobs:
     # The workaround from https://github.com/actions/setup-dotnet/issues/155#issuecomment-748452076
     - name: Clean
       run: msbuild LoginApp.sln /t:clean /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration && dotnet nuget locals all --clear
+      working-directory: samples
+      env:
+        Configuration: ${{ matrix.configuration }}
 
     - name: Restore/Build the sample
       run: msbuild LoginApp.sln /t:restore,build /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -38,13 +38,13 @@ jobs:
       with:
         dotnet-version: 5.0.x
 
-    # The workaround from https://github.com/actions/setup-dotnet/issues/155#issuecomment-748452076
-    - name: Clean
-      run: msbuild LoginApp.sln /t:clean /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration && dotnet nuget locals all --clear
-
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
+
+    # The workaround from https://github.com/actions/setup-dotnet/issues/155#issuecomment-748452076
+    - name: Clean
+      run: msbuild LoginApp.sln /t:clean /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration && dotnet nuget locals all --clear
 
     - name: Restore/Build the sample
       run: msbuild LoginApp.sln /t:restore,build /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR attempts to fix the CI build errors that dependabot hits while trying to update stuff. Based on https://github.com/reactiveui/ReactiveUI.Validation/pull/188#issuecomment-749462434