### PR TITLE
fix: Remove maxcpucount from GitHub Actions

### DIFF
--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -50,7 +50,7 @@ jobs:
         Configuration: ${{ matrix.configuration }}
 
     - name: Restore/Build the sample
-      run: msbuild LoginApp.sln /t:restore,build /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration
+      run: msbuild LoginApp.sln /t:restore,build /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=$env:Configuration
       working-directory: samples
       env:
         Configuration: ${{ matrix.configuration }}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Planning to continue https://github.com/reactiveui/ReactiveUI.Validation/pull/190#issuecomment-749474150 investigation in this PR. This PR actually removes `/maxcpucount` from `Restore/Build the sample` task. Planning to rerun the CI a couple of times to verify.