### PR TITLE
feature: Use ReactiveUI bindings in the Avalonia sample app

### DIFF
--- a/samples/LoginApp.Avalonia/LoginApp.Avalonia.csproj
+++ b/samples/LoginApp.Avalonia/LoginApp.Avalonia.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="0.10.0" />
         <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
         <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.0" />
-        <PackageReference Include="Citrus.Avalonia" Version="1.3.0-preview" />
+        <PackageReference Include="Citrus.Avalonia" Version="1.4.3" />
         <PackageReference Include="MessageBox.Avalonia" Version="1.0.5" />
+        <PackageReference Include="XamlNameReferenceGenerator" Version="0.1.4" />
     </ItemGroup>
 
     <ItemGroup>
@@ -23,5 +24,7 @@
         <EmbeddedResource Include="**\*.xaml">
             <SubType>Designer</SubType>
         </EmbeddedResource>
+        <!-- This AdditionalFiles directive is required by XamlNameReferenceGenerator. -->
+        <AdditionalFiles Include="**\*.xaml" />
     </ItemGroup>
 </Project>

--- a/samples/LoginApp.Avalonia/Views/SignUpView.xaml
+++ b/samples/LoginApp.Avalonia/Views/SignUpView.xaml
@@ -8,14 +8,14 @@
                 <Grid ColumnDefinitions="Auto, *">
                     <TextBlock Grid.Column="0" Classes="Heading" Text="Sign Up" />
                     <Ellipse Grid.Column="1"
+                             x:Name="BudyIndicator"
                              Width="5" Height="5"
                              HorizontalAlignment="Left"
                              VerticalAlignment="Center"
-                             IsVisible="{Binding IsBusy}"
                              Fill="Red" Margin="7 7 5 3" />
                 </Grid>
                 <TextBox Margin="0 10 0 0"
-                         Text="{Binding UserName}" 
+                         x:Name="UserNameTextBox"
                          Watermark="Please, enter user name..."
                          UseFloatingWatermark="True" />
                 <TextBlock x:Name="UserNameValidation" 
@@ -23,7 +23,7 @@
                            FontSize="12" />
                 
                 <TextBox Margin="0 10 0 0"
-                         Text="{Binding Password}" 
+                         x:Name="PasswordTextBox"
                          Watermark="Please, enter your password..."
                          UseFloatingWatermark="True"
                          PasswordChar="*" />
@@ -32,7 +32,7 @@
                            FontSize="12" />
                 
                 <TextBox Margin="0 10 0 0"
-                         Text="{Binding ConfirmPassword}" 
+                         x:Name="ConfirmPasswordTextBox"
                          Watermark="Please, confirm the password..."
                          UseFloatingWatermark="True"
                          PasswordChar="*" />
@@ -42,8 +42,8 @@
                            FontSize="12" />
                 
                 <Button Margin="0 10 0 5"
-                        Content="Sign up" 
-                        Command="{Binding SignUp}" />
+                        Content="Sign up"
+                        x:Name="SignUpButton" />
                 <TextBlock x:Name="CompoundValidation"
                            TextWrapping="Wrap"
                            Foreground="Red"

--- a/samples/LoginApp.Avalonia/Views/SignUpView.xaml.cs
+++ b/samples/LoginApp.Avalonia/Views/SignUpView.xaml.cs
@@ -19,7 +19,8 @@ namespace LoginApp.Avalonia.Views
     /// A page which contains controls for signing up.
     /// </summary>
     /// <inheritdoc />
-    public class SignUpView : ReactiveWindow<SignUpViewModel>
+    [GenerateTypedNameReferences]
+    public partial class SignUpView : ReactiveWindow<SignUpViewModel>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SignUpView"/> class.
@@ -29,6 +30,20 @@ namespace LoginApp.Avalonia.Views
             AvaloniaXamlLoader.Load(this);
             this.WhenActivated(disposables =>
             {
+                // Standard ReactiveUI bindings.
+                this.Bind(ViewModel, x => x.UserName, x => x.UserNameTextBox.Text)
+                    .DisposeWith(disposables);
+                this.Bind(ViewModel, x => x.Password, x => x.PasswordTextBox.Text)
+                    .DisposeWith(disposables);
+                this.Bind(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordTextBox.Text)
+                    .DisposeWith(disposables);
+                this.BindCommand(ViewModel, x => x.SignUp, x => x.SignUpButton)
+                    .DisposeWith(disposables);
+
+                this.OneWayBind(ViewModel, x => x.IsBusy, x => x.BudyIndicator.IsVisible)
+                    .DisposeWith(disposables);
+
+                // ReactiveUI.Validation: Bindings for error messages.
                 this.BindValidation(ViewModel, x => x.UserName, x => x.UserNameValidation.Text)
                     .DisposeWith(disposables);
                 this.BindValidation(ViewModel, x => x.Password, x => x.PasswordValidation.Text)
@@ -36,18 +51,11 @@ namespace LoginApp.Avalonia.Views
                 this.BindValidation(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordValidation.Text)
                     .DisposeWith(disposables);
 
+                // ReactiveUI.Validation: Compound validation bindings.
                 var newLineFormatter = new SingleLineFormatter(Environment.NewLine);
                 this.BindValidation(ViewModel, x => x.CompoundValidation.Text, newLineFormatter)
                     .DisposeWith(disposables);
             });
         }
-
-        private TextBlock ConfirmPasswordValidation => this.FindControl<TextBlock>("ConfirmPasswordValidation");
-
-        private TextBlock UserNameValidation => this.FindControl<TextBlock>("UserNameValidation");
-
-        private TextBlock PasswordValidation => this.FindControl<TextBlock>("PasswordValidation");
-
-        private TextBlock CompoundValidation => this.FindControl<TextBlock>("CompoundValidation");
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR incorporates [Avalonia.NameGenerator](https://github.com/avaloniaui/avalonia.namegenerator) package that allows us to use ReactiveUI code-behind bindings and ReactiveUI.Validation bindings without writing any boilerplate code. This source generator generates strongly typed references to named Avalonia controls declared in XAML files, at compile time (almost like WPF or Windows.Forms do). 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

We are mixing ReactiveUI markup bindings and code-behind bindings in `LoginApp.Avalonia`.
Also, we are writing `FindControl` getters by hand in the `.xaml.cs` file of our view class.

**What is the new behavior?**
<!-- If this is a feature change -->

The bindings in our updated Avalonia sample app should look pretty concise now, and we no longer have to mix markup bindings and code-behind bindings. 

**What might this PR break?**

Hopefully nothing, we are targeting .NET 5 anyway now.