### PR TITLE
Update README.md by adding additional note about INotifyDataErrorInfo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ public class SampleViewModel : ReactiveValidationObject
 }
 ```
 
-> **Note** Keep in mind that `INotifyDataErrorInfo` is only supported via XAML binding. ReactiveUI binding doesn't use the inbuilt classes of the WPF.
+> **Note** Keep in mind that `INotifyDataErrorInfo` is only supported via XAML binding. ReactiveUI binding doesn't use the inbuilt classes of WPF.
 
 When using a `ValidationRule` overload that accepts an observable, please remember to supply the property which the validation rule is targeting as the first argument. Otherwise it is not possible for `INotifyDataErrorInfo` to conclude which property the error message is for.
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ public class SampleViewModel : ReactiveValidationObject
 }
 ```
 
+> **Note** Keep in mind that `INotifyDataErrorInfo` is only supported via XAML binding. ReactiveUI binding doesn't use the inbuilt classes of the WPF.
+
 When using a `ValidationRule` overload that accepts an observable, please remember to supply the property which the validation rule is targeting as the first argument. Otherwise it is not possible for `INotifyDataErrorInfo` to conclude which property the error message is for.
 
 ```csharp


### PR DESCRIPTION
**What kind of change does this PR introduce?**
It's a README.md update to clarify how `INotifyDataErrorInfo` support works.

**What is the current behavior?**
Current doc is too general in `INotifyDataErrorInfo` area and can be misleading for new users of the ReactiveUI and the ReactiveUI.Validtaion. There is a question about it #237.

**What is the new behavior?**
Note added to README.md, that `INotifyDataErrorInfo` requires regular binding in WPF.

**What might this PR break?**
Nothing.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

