### PR TITLE
fix: ValidationContext.ValidationText Nullability

### DIFF
--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net461.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net461.approved.txt
@@ -110,7 +110,7 @@ namespace ReactiveUI.Validation.Contexts
     {
         public ValidationContext(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public bool IsValid { get; }
-        public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
+        public ReactiveUI.Validation.Collections.ValidationText Text { get; }
         public System.IObservable<bool> Valid { get; }
         public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         public System.Collections.ObjectModel.ReadOnlyObservableCollection<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net472.approved.txt
@@ -110,7 +110,7 @@ namespace ReactiveUI.Validation.Contexts
     {
         public ValidationContext(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public bool IsValid { get; }
-        public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
+        public ReactiveUI.Validation.Collections.ValidationText Text { get; }
         public System.IObservable<bool> Valid { get; }
         public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         public System.Collections.ObjectModel.ReadOnlyObservableCollection<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net5.0.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net5.0.approved.txt
@@ -110,7 +110,7 @@ namespace ReactiveUI.Validation.Contexts
     {
         public ValidationContext(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public bool IsValid { get; }
-        public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
+        public ReactiveUI.Validation.Collections.ValidationText Text { get; }
         public System.IObservable<bool> Valid { get; }
         public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         public System.Collections.ObjectModel.ReadOnlyObservableCollection<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.netcoreapp3.1.approved.txt
@@ -110,7 +110,7 @@ namespace ReactiveUI.Validation.Contexts
     {
         public ValidationContext(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
         public bool IsValid { get; }
-        public ReactiveUI.Validation.Collections.ValidationText? Text { get; }
+        public ReactiveUI.Validation.Collections.ValidationText Text { get; }
         public System.IObservable<bool> Valid { get; }
         public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
         public System.Collections.ObjectModel.ReadOnlyObservableCollection<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -131,7 +131,7 @@ namespace ReactiveUI.Validation.Contexts
         }
 
         /// <inheritdoc />
-        public ValidationText? Text
+        public ValidationText Text
         {
             get
             {


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR fixes the` ValidationContext.Text` property nullability issue discovered in the newest versions of the .NET SDK.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Currently, our CI build is [broken](https://github.com/reactiveui/ReactiveUI.Validation/runs/3388854682).
`
Error: D:\a\ReactiveUI.Validation\ReactiveUI.Validation\src\ReactiveUI.Validation\Contexts\ValidationContext.cs(82,31): error CS8619: Nullability of reference types in value of type 'ObservableAsPropertyHelper<ValidationText?>' doesn't match target type 'ObservableAsPropertyHelper<ValidationText>'. [D:\a\ReactiveUI.Validation\ReactiveUI.Validation\src\ReactiveUI.Validation\ReactiveUI.Validation.csproj]
`

**What is the new behavior?**
<!-- If this is a feature change -->

From now on, the build is no longer broken.

**What might this PR break?**

Nothing.
