### PR TITLE
Housekeeping Remove Unsupported Targets

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,5 +12,5 @@ jobs:
     with:
       configuration: Release
       productNamespacePrefix: "ReactiveUI.Validation"
-      useVisualStudioPreview: false
+      useVisualStudioPreview: true
       useMauiCheckDotNetTool: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       configuration: Release
       productNamespacePrefix: "ReactiveUI.Validation"
-      useVisualStudioPreview: false
+      useVisualStudioPreview: true
       useMauiCheckDotNetTool: false
     secrets:
       SIGN_CLIENT_USER_ID: ${{ secrets.SIGN_CLIENT_USER_ID }}

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -41,7 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.435" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.1.2" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.2.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />

--- a/src/ReactiveUI.Validation.AndroidSupport/ReactiveUI.Validation.AndroidSupport.csproj
+++ b/src/ReactiveUI.Validation.AndroidSupport/ReactiveUI.Validation.AndroidSupport.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>MonoAndroid12.1</TargetFramework>
+    <TargetFrameworks>MonoAndroid12.0;MonoAndroid12.1;MonoAndroid13.0</TargetFrameworks>
     <PackageDescription>Provides ReactiveUI.Validation extensions for the Android Support Library</PackageDescription>
     <PackageId>ReactiveUI.Validation.AndroidSupport</PackageId>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/ReactiveUI.Validation.AndroidX/ReactiveUI.Validation.AndroidX.csproj
+++ b/src/ReactiveUI.Validation.AndroidX/ReactiveUI.Validation.AndroidX.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.1;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid12.0;MonoAndroid12.1;MonoAndroid13.0;net6.0-android;net7.0-android</TargetFrameworks>
     <PackageDescription>Provides ReactiveUI.Validation extensions for the AndroidX Library</PackageDescription>
     <PackageId>ReactiveUI.Validation.AndroidX</PackageId>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net6.0.approved.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.net6.0.approved.txt
@@ -1,5 +1,5 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/reactiveui/reactiveui.validation")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace ReactiveUI.Validation.Abstractions
 {
     public interface IValidatableViewModel

--- a/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
+++ b/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>MonoAndroid12.0;MonoAndroid12.1;MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netstandard2.0;net6.0;net6.0-android;net6.0-ios;net6.0-tvos;net6.0-macos;net6.0-maccatalyst;net7.0;net7.0-android;net7.0-ios;net7.0-tvos;net7.0-macos;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;uap10.0.17763;net6.0-windows;net6.0-windows10.0.17763;net7.0-windows;net7.0-windows10.0.17763</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;net6.0-windows;net6.0-windows10.0.17763;net7.0-windows;net7.0-windows10.0.17763</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
+++ b/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.1;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netstandard2.0;net6.0;net6.0-android;net6.0-ios;net6.0-tvos;net6.0-macos;net6.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;uap10.0.16299;net6.0-windows;net6.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid12.0;MonoAndroid12.1;MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netstandard2.0;net6.0;net6.0-android;net6.0-ios;net6.0-tvos;net6.0-macos;net6.0-maccatalyst;net7.0;net7.0-android;net7.0-ios;net7.0-tvos;net7.0-macos;net7.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;uap10.0.17763;net6.0-windows;net6.0-windows10.0.17763;net7.0-windows;net7.0-windows10.0.17763</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0",
+    "version": "3.1",
     "publicReleaseRefSpec": [
         "^refs/heads/main$",
         "^refs/heads/latest$",


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

Old targets

**What is the new behaviour?**
<!-- If this is a feature change -->

Add MonoAndroid12.0 and MonoAndroid13.0
Add Net 7.0
Update uap10.0.16299 to uap10.0.17763

**What might this PR break?**

Non expected

**Please check if the PR fulfils these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

