### PR TITLE
Fix issue when using ReactiveUI 19.5.31 which includes System.Text.Json

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -37,8 +37,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
-    <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.507" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.6.2" PrivateAssets="All" />
+    <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.7.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />

--- a/src/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj
+++ b/src/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj
@@ -11,18 +11,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit.runner.console" Version="2.6.4" />
     <PackageReference Include="Xunit.StaFact" Version="1.1.11" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.0" />
-    <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
-    <PackageReference Include="Verify.Xunit" Version="22.8.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
+    <PackageReference Include="Verify.Xunit" Version="22.11.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="DiffEngine" Version="13.0.2" />    
+    <PackageReference Include="DiffEngine" Version="15.0.1" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Validation/Collections/ReadOnlyCollectionPooled.cs
+++ b/src/ReactiveUI.Validation/Collections/ReadOnlyCollectionPooled.cs
@@ -59,9 +59,9 @@ internal sealed class ReadOnlyCollectionPooled<T> : IReadOnlyCollection<T>, IDis
             _current = default;
         }
 
-        public T Current => _current!;
+        public readonly T Current => _current!;
 
-        object? IEnumerator.Current
+        readonly object? IEnumerator.Current
         {
             get
             {

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -18,7 +18,7 @@ public static class ValidationText
     /// <summary>
     /// The none validation text singleton instance contains no items.
     /// </summary>
-    public static readonly IValidationText None = new ArrayValidationText(Array.Empty<string>());
+    public static readonly IValidationText None = new ArrayValidationText([]);
 
     /// <summary>
     /// The empty validation text singleton instance contains single empty string.

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -29,8 +29,8 @@ public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisp
 {
     [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
     private readonly ReplaySubject<bool> _isValidSubject = new(1);
-    private readonly HashSet<string> _propertyNames = new();
-    private readonly CompositeDisposable _disposables = new();
+    private readonly HashSet<string> _propertyNames = [];
+    private readonly CompositeDisposable _disposables = [];
     private IConnectableObservable<IValidationState>? _connectedChange;
     private bool _isConnected;
     private bool _isValid;
@@ -171,7 +171,7 @@ public sealed class BasePropertyValidation<TViewModel, TViewModelProperty> : Bas
     private readonly IConnectableObservable<TViewModelProperty?> _valueConnectedObservable;
     private readonly Func<TViewModelProperty?, bool, IValidationText> _message;
     private readonly Func<TViewModelProperty?, bool> _isValidFunc;
-    private readonly CompositeDisposable _disposables = new();
+    private readonly CompositeDisposable _disposables = [];
     private bool _isConnected;
 
     /// <summary>

--- a/src/ReactiveUI.Validation/Components/ObservableValidation.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation.cs
@@ -241,8 +241,8 @@ public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObj
 {
     [SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Disposed by field _disposables.")]
     private readonly ReplaySubject<IValidationState> _isValidSubject = new(1);
-    private readonly HashSet<string> _propertyNames = new();
-    private readonly CompositeDisposable _disposables = new();
+    private readonly HashSet<string> _propertyNames = [];
+    private readonly CompositeDisposable _disposables = [];
     private readonly IConnectableObservable<IValidationState> _validityConnectedObservable;
     private bool _isActive;
     private bool _isValid;

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -42,7 +42,7 @@ public class ValidationContext : ReactiveObject, IDisposable, IValidationCompone
     private readonly ObservableAsPropertyHelper<IValidationText> _validationText;
     private readonly ObservableAsPropertyHelper<bool> _isValid;
 
-    private readonly CompositeDisposable _disposables = new();
+    private readonly CompositeDisposable _disposables = [];
     private bool _isActive;
 
     /// <summary>

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -27,7 +27,7 @@ namespace ReactiveUI.Validation.Helpers;
 /// </summary>
 public abstract class ReactiveValidationObject : ReactiveObject, IValidatableViewModel, INotifyDataErrorInfo
 {
-    private readonly HashSet<string> _mentionedPropertyNames = new();
+    private readonly HashSet<string> _mentionedPropertyNames = [];
     private readonly IValidationTextFormatter<string> _formatter;
     private bool _hasErrors;
 

--- a/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
+++ b/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks>MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;tizen40;netstandard2.0;net6.0;net7.0;net7.0-android;net7.0-ios;net7.0-tvos;net7.0-macos;net7.0-maccatalyst;net8.0;net8.0-android;net8.0-ios;net8.0-tvos;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
@@ -7,14 +7,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="19.*" />
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('Xamarin'))">
+    <PackageReference Include="ReactiveUI" Version="19.5.31" />
   </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
+  
+  <!--Xamarin does not support System.Text.Json due to the inclusion of System.Buffers, the latest version (19.5.31) of ReactiveUI includes System.Text.Json-->
+  <ItemGroup Condition="$(TargetFramework.StartsWith('Xamarin'))">
+    <PackageReference Include="ReactiveUI" Version="19.5.1" />
   </ItemGroup>
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,8 +1,7 @@
 {
     "sdk": {
         "version": "8.0.10",
-        "rollForward": "latestMinor",
-        "allowPrerelease": true
+        "rollForward": "latestMinor"
     },
     "msbuild-sdks": {
         "MSBuild.Sdk.Extras": "3.0.44"


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Xamarin does not support System.Text.Json due to the inclusion of System.Buffers, Xamarin falls back to Netstandard2.0 within the package causing the System.Buffers lib to load

**What is the new behavior?**
<!-- If this is a feature change -->

Xamarin targets use ReactiveUI 19.5.1 other targets use 19.5.31

**What might this PR break?**

None known

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

