### PR TITLE
Add .NET 9 support and update dependencies

### DIFF
--- a/src/ReactiveUI.Validation.AndroidX/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation.AndroidX/Extensions/ViewForExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation.AndroidX/ReactiveUI.Validation.AndroidX.csproj
+++ b/src/ReactiveUI.Validation.AndroidX/ReactiveUI.Validation.AndroidX.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android</TargetFrameworks>
+    <TargetFrameworks>net8.0-android;net9.0-android</TargetFrameworks>
     <PackageDescription>Provides ReactiveUI.Validation extensions for the AndroidX Library</PackageDescription>
     <PackageId>ReactiveUI.Validation.AndroidX</PackageId>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.AndroidX" Version="20.4.1" />
+    <PackageReference Include="ReactiveUI.AndroidX" Version="21.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.DotNet9_0.verified.txt
+++ b/src/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.DotNet9_0.verified.txt
@@ -1,0 +1,272 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName=".NET 9.0")]
+namespace ReactiveUI.Validation.Abstractions
+{
+    public interface IValidatableViewModel
+    {
+        ReactiveUI.Validation.Contexts.IValidationContext ValidationContext { get; }
+    }
+}
+namespace ReactiveUI.Validation.Collections
+{
+    public interface IValidationText : System.Collections.Generic.IEnumerable<string>, System.Collections.Generic.IReadOnlyCollection<string>, System.Collections.Generic.IReadOnlyList<string>, System.Collections.IEnumerable
+    {
+        string ToSingleLine(string? separator = ",");
+    }
+    public static class ValidationText
+    {
+        public static readonly ReactiveUI.Validation.Collections.IValidationText Empty;
+        public static readonly ReactiveUI.Validation.Collections.IValidationText None;
+        public static ReactiveUI.Validation.Collections.IValidationText Create(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Collections.IValidationText>? validationTexts) { }
+        public static ReactiveUI.Validation.Collections.IValidationText Create(System.Collections.Generic.IEnumerable<string?>? validationTexts) { }
+        public static ReactiveUI.Validation.Collections.IValidationText Create(string? validationText) { }
+        public static ReactiveUI.Validation.Collections.IValidationText Create(params string?[]? validationTexts) { }
+    }
+}
+namespace ReactiveUI.Validation.Comparators
+{
+    public class ValidationStateComparer : System.Collections.Generic.EqualityComparer<ReactiveUI.Validation.States.IValidationState>
+    {
+        public ValidationStateComparer() { }
+        public override bool Equals(ReactiveUI.Validation.States.IValidationState? x, ReactiveUI.Validation.States.IValidationState? y) { }
+        public override int GetHashCode(ReactiveUI.Validation.States.IValidationState obj) { }
+    }
+}
+namespace ReactiveUI.Validation.Components.Abstractions
+{
+    public interface IPropertyValidationComponent : ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent { }
+    public interface IValidatesProperties
+    {
+        System.Collections.Generic.IEnumerable<string> Properties { get; }
+        int PropertyCount { get; }
+        bool ContainsPropertyName(string propertyName, bool exclusively = false);
+    }
+    public interface IValidationComponent
+    {
+        bool IsValid { get; }
+        ReactiveUI.Validation.Collections.IValidationText? Text { get; }
+        System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
+    }
+}
+namespace ReactiveUI.Validation.Components
+{
+    public abstract class BasePropertyValidation<TViewModel> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    {
+        protected BasePropertyValidation() { }
+        public bool IsValid { get; }
+        public System.Collections.Generic.IEnumerable<string> Properties { get; }
+        public int PropertyCount { get; }
+        public ReactiveUI.Validation.Collections.IValidationText? Text { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
+        protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        protected abstract System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable();
+    }
+    public sealed class BasePropertyValidation<TViewModel, TViewModelProperty> : ReactiveUI.Validation.Components.BasePropertyValidation<TViewModel>
+    {
+        public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty?>> viewModelProperty, System.Func<TViewModelProperty?, bool> isValidFunc, System.Func<TViewModelProperty?, string> message) { }
+        public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty?>> viewModelProperty, System.Func<TViewModelProperty?, bool> isValidFunc, System.Func<TViewModelProperty?, bool, string> messageFunc) { }
+        public BasePropertyValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty?>> viewModelProperty, System.Func<TViewModelProperty?, bool> isValidFunc, string message) { }
+        protected override void Dispose(bool disposing) { }
+        protected override System.IObservable<ReactiveUI.Validation.States.IValidationState> GetValidationChangeObservable() { }
+    }
+    public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Components.Abstractions.IPropertyValidationComponent, ReactiveUI.Validation.Components.Abstractions.IValidatesProperties, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, System.IDisposable
+    {
+        protected ObservableValidationBase(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        protected ObservableValidationBase(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, ReactiveUI.Validation.Collections.IValidationText> messageFunc) { }
+        public bool IsValid { get; }
+        public System.Collections.Generic.IEnumerable<string> Properties { get; }
+        public int PropertyCount { get; }
+        public ReactiveUI.Validation.Collections.IValidationText? Text { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
+        protected void AddProperty<TProp>(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> property) { }
+        public bool ContainsPropertyName(string propertyName, bool exclusively = false) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+    }
+    public sealed class ObservableValidation<TViewModel, TValue> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
+    {
+        public ObservableValidation(System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
+        public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
+        public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, string> messageFunc) { }
+        public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
+        public ObservableValidation(TViewModel viewModel, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
+    }
+    public sealed class ObservableValidation<TViewModel, TValue, TProp> : ReactiveUI.Validation.Components.ObservableValidationBase<TViewModel, TValue>
+    {
+        public ObservableValidation(System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<ReactiveUI.Validation.States.IValidationState> observable) { }
+        public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc) { }
+        public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TValue, bool> isValidFunc, string message) { }
+        public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, string> messageFunc) { }
+        public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, System.Func<TViewModel, TValue, bool, string> messageFunc) { }
+        public ObservableValidation(TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> viewModelProperty, System.IObservable<TValue> observable, System.Func<TViewModel, TValue, bool> isValidFunc, string message) { }
+    }
+}
+namespace ReactiveUI.Validation.Contexts
+{
+    public interface IValidationContext : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable, System.Reactive.Disposables.ICancelable
+    {
+        System.IObservable<bool> Valid { get; }
+        DynamicData.IObservableList<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }
+        void Add(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation);
+        bool GetIsValid();
+        void Remove(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation);
+        void RemoveMany(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> validations);
+    }
+    public class ValidationContext : ReactiveUI.ReactiveObject, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, ReactiveUI.Validation.Contexts.IValidationContext, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable, System.Reactive.Disposables.ICancelable
+    {
+        public ValidationContext(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public bool IsDisposed { get; }
+        public bool IsValid { get; }
+        public ReactiveUI.Validation.Collections.IValidationText Text { get; }
+        public System.IObservable<bool> Valid { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationStatusChange { get; }
+        public DynamicData.IObservableList<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }
+        public void Add(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public bool GetIsValid() { }
+        public void Remove(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation) { }
+        public void RemoveMany(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> validations) { }
+    }
+}
+namespace ReactiveUI.Validation.Extensions
+{
+    public static class ValidatableViewModelExtensions
+    {
+        public static void ClearValidationRules<TViewModel>(this TViewModel viewModel)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static void ClearValidationRules<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static System.IObservable<bool> IsValid<TViewModel>(this TViewModel viewModel)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.IObservable<ReactiveUI.Validation.States.IValidationState> validationObservable)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel>(this TViewModel viewModel, System.IObservable<bool> validationObservable, string message)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TValue>(this TViewModel viewModel, System.IObservable<TValue> validationObservable)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel
+            where TValue : ReactiveUI.Validation.States.IValidationState { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.IObservable<ReactiveUI.Validation.States.IValidationState> validationObservable)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TValue>(this TViewModel viewModel, System.IObservable<TValue> validationObservable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.IObservable<bool> viewModelObservable, string message)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp?>> viewModelProperty, System.Func<TViewModelProp?, bool> isPropertyValid, System.Func<TViewModelProp?, string> message)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp?>> viewModelProperty, System.Func<TViewModelProp?, bool> isPropertyValid, string message)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp, TValue>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.IObservable<TValue> validationObservable)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel
+            where TValue : ReactiveUI.Validation.States.IValidationState { }
+        public static ReactiveUI.Validation.Helpers.ValidationHelper ValidationRule<TViewModel, TViewModelProp, TValue>(this TViewModel viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProp>> viewModelProperty, System.IObservable<TValue> viewModelObservable, System.Func<TValue, bool> isValidFunc, System.Func<TValue, string> messageFunc)
+            where TViewModel : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+    }
+    public static class ValidatesPropertiesExtensions
+    {
+        public static bool ContainsProperty<TViewModel, TProp>(this ReactiveUI.Validation.Components.Abstractions.IValidatesProperties validatesProperties, System.Linq.Expressions.Expression<System.Func<TViewModel, TProp>> propertyExpression, bool exclusively = false) { }
+    }
+    public static class ValidationContextExtensions
+    {
+        public static System.IObservable<System.Collections.Generic.IList<ReactiveUI.Validation.States.IValidationState>> ObserveFor<TViewModel, TViewModelProperty>(this ReactiveUI.Validation.Contexts.IValidationContext context, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, bool strict = true) { }
+    }
+    public static class ViewForExtensions
+    {
+        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+            where TView : ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static System.IDisposable BindValidation<TView, TViewModel, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper?>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+            where TView : ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static System.IDisposable BindValidation<TView, TViewModel, TViewModelProperty, TViewProperty>(this TView view, TViewModel? viewModel, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+            where TView : ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+    }
+}
+namespace ReactiveUI.Validation.Formatters.Abstractions
+{
+    public interface IValidationTextFormatter<out TOut>
+    {
+        TOut Format(ReactiveUI.Validation.Collections.IValidationText validationText);
+    }
+}
+namespace ReactiveUI.Validation.Formatters
+{
+    public class SingleLineFormatter : ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>
+    {
+        public SingleLineFormatter(string? separator = null) { }
+        public static ReactiveUI.Validation.Formatters.SingleLineFormatter Default { get; }
+        public string Format(ReactiveUI.Validation.Collections.IValidationText? validationText) { }
+    }
+}
+namespace ReactiveUI.Validation.Helpers
+{
+    public abstract class ReactiveValidationObject : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo, System.IDisposable
+    {
+        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
+        public bool HasErrors { get; }
+        public ReactiveUI.Validation.Contexts.IValidationContext ValidationContext { get; }
+        public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs>? ErrorsChanged;
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public virtual System.Collections.IEnumerable GetErrors(string? propertyName) { }
+        protected void RaiseErrorsChanged(string propertyName = "") { }
+    }
+    public class ValidationHelper : ReactiveUI.ReactiveObject, System.IDisposable
+    {
+        public ValidationHelper(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation, System.IDisposable? cleanup = null) { }
+        public bool IsValid { get; }
+        public ReactiveUI.Validation.Collections.IValidationText Message { get; }
+        public System.IObservable<ReactiveUI.Validation.States.IValidationState> ValidationChanged { get; }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+    }
+}
+namespace ReactiveUI.Validation.States
+{
+    public interface IValidationState
+    {
+        bool IsValid { get; }
+        ReactiveUI.Validation.Collections.IValidationText Text { get; }
+    }
+    public class ValidationState : ReactiveUI.Validation.States.IValidationState
+    {
+        public static readonly ReactiveUI.Validation.States.IValidationState Valid;
+        public ValidationState(bool isValid, ReactiveUI.Validation.Collections.IValidationText text) { }
+        public ValidationState(bool isValid, string text) { }
+        public bool IsValid { get; }
+        public ReactiveUI.Validation.Collections.IValidationText Text { get; }
+    }
+}
+namespace ReactiveUI.Validation.ValidationBindings.Abstractions
+{
+    public interface IValidationBinding : System.IDisposable { }
+}
+namespace ReactiveUI.Validation.ValidationBindings
+{
+    public sealed class ValidationBinding : ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding, System.IDisposable
+    {
+        public void Dispose() { }
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Action<System.Collections.Generic.IList<ReactiveUI.Validation.States.IValidationState>, System.Collections.Generic.IList<TOut>> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter, bool strict = true)
+            where TView : ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForProperty<TView, TViewModel, TViewModelProperty, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel, TViewModelProperty>> viewModelProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null, bool strict = true)
+            where TView : ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TOut>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper?>> viewModelHelperProperty, System.Action<ReactiveUI.Validation.States.IValidationState, TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
+            where TView : ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForValidationHelperProperty<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TViewModel?, ReactiveUI.Validation.Helpers.ValidationHelper?>> viewModelHelperProperty, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+            where TView : ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TOut>(TView view, System.Action<TOut> action, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<TOut> formatter)
+            where TView : ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+        public static ReactiveUI.Validation.ValidationBindings.Abstractions.IValidationBinding ForViewModel<TView, TViewModel, TViewProperty>(TView view, System.Linq.Expressions.Expression<System.Func<TView, TViewProperty>> viewProperty, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null)
+            where TView : ReactiveUI.IViewFor<TViewModel>
+            where TViewModel :  class, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel { }
+    }
+}

--- a/src/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj
+++ b/src/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633</NoWarn>
   </PropertyGroup>
 
@@ -10,13 +10,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3" />
     <PackageReference Include="Xunit.StaFact" Version="1.2.69" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.2" />
     <PackageReference Include="PublicApiGenerator" Version="11.4.6" />
-    <PackageReference Include="Verify.Xunit" Version="30.7.3" />
+    <PackageReference Include="Verify.Xunit" Version="30.10.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/src/ReactiveUI.Validation.sln
+++ b/src/ReactiveUI.Validation.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# 17
+# Visual Studio Version 17
 VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.Validation", "ReactiveUI.Validation\ReactiveUI.Validation.csproj", "{B62AABD0-22A4-470D-B6EB-F6B3EAE668DE}"
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.build.props = Directory.build.props
 		Directory.build.targets = Directory.build.targets
 		global.json = global.json
+		..\README.md = ..\README.md
 		stylecop.json = stylecop.json
 		..\version.json = ..\version.json
 	EndProjectSection

--- a/src/ReactiveUI.Validation/Abstractions/IValidatableViewModel.cs
+++ b/src/ReactiveUI.Validation/Abstractions/IValidatableViewModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Collections/ArrayValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ArrayValidationText.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Collections/IValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/IValidationText.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Collections/ReadOnlyDisposableCollection{T}.cs
+++ b/src/ReactiveUI.Validation/Collections/ReadOnlyDisposableCollection{T}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Collections/SingleValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/SingleValidationText.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Comparators/ValidationStateComparer.cs
+++ b/src/ReactiveUI.Validation/Comparators/ValidationStateComparer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IPropertyValidationComponent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidationComponent.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidationComponent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Components/ObservableValidationBase{TViewModel,TValue}.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidationBase{TViewModel,TValue}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Components/ObservableValidation{TViewModel,TValue,TProp}.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation{TViewModel,TValue,TProp}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Components/ObservableValidation{TViewModel,TValue}.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation{TViewModel,TValue}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Contexts/IValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/IValidationContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Extensions/ArrayPoolExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ArrayPoolExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Extensions/ExpressionExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ExpressionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Extensions/ValidatesPropertiesExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatesPropertiesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Formatters/Abstractions/IValidationTextFormatter.cs
+++ b/src/ReactiveUI.Validation/Formatters/Abstractions/IValidationTextFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Formatters/SingleLineFormatter.cs
+++ b/src/ReactiveUI.Validation/Formatters/SingleLineFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/Helpers/ValidationHelper.cs
+++ b/src/ReactiveUI.Validation/Helpers/ValidationHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
+++ b/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net8.0-android;net8.0-ios;net8.0-tvos;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;net6.0-windows10.0.17763.0;net8.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net8.0-android;net8.0-ios;net8.0-tvos;net8.0-macos;net8.0-maccatalyst;net9.0;net9.0-android;net9.0-ios;net9.0-tvos;net9.0-macos;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="20.4.1" />    
+    <PackageReference Include="ReactiveUI" Version="21.0.1" />    
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) or $(TargetFramework.StartsWith('net4'))">

--- a/src/ReactiveUI.Validation/States/IValidationState.cs
+++ b/src/ReactiveUI.Validation/States/IValidationState.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/States/ValidationState.cs
+++ b/src/ReactiveUI.Validation/States/ValidationState.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/ValidationBindings/Abstractions/IValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/Abstractions/IValidationBinding.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -13,7 +13,7 @@
             "documentPrivateFields": false,
             "documentationCulture": "en-US",
             "companyName": ".NET Foundation and Contributors",
-            "copyrightText": "Copyright (c) 2024 {companyName}. All rights reserved.\nLicensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
+            "copyrightText": "Copyright (c) 2025 {companyName}. All rights reserved.\nLicensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
             "variables": {
                 "licenseName": "MIT",
                 "licenseFile": "LICENSE"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.1",
+    "version": "5.0",
     "publicReleaseRefSpec": [
         "^refs/heads/main$",
         "^refs/heads/latest$",


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update to match latest ReactiveUI and Splat

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request updates the AndroidX validation extension to support newer frameworks and dependencies. The main changes ensure compatibility with the latest Android platform and ReactiveUI.AndroidX library.

Platform and dependency updates:

* Added support for `net9.0-android` in the `TargetFrameworks` property of `ReactiveUI.Validation.AndroidX.csproj`.
* Upgraded the `ReactiveUI.AndroidX` package reference to version `21.0.1` in `ReactiveUI.Validation.AndroidX.csproj`.

Maintenance:

* Updated the copyright year to 2025 in `ViewForExtensions.cs`.

**What might this PR break?**

none expected, bumped major version due to ReactiveUI and Splat major change and compatability

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

