### PR TITLE
Update CI workflow permissions for actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,9 +6,16 @@ on:
   pull_request:
     branches: [ main ]
 
+# Needed so the reusable workflow can optionally delete the temp per-OS artifacts it creates.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     uses: reactiveui/actions-common/.github/workflows/workflow-common-setup-and-build.yml@main
     with:
       configuration: Release
       productNamespacePrefix: "ReactiveUI.Validation"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update


This pull request updates the CI build workflow configuration to enhance permissions and securely pass secrets to the reusable workflow.

**CI workflow improvements:**

* Added `permissions` for `contents: read` and `actions: write` to allow the reusable workflow to optionally delete temporary per-OS artifacts.
* Passed the `CODECOV_TOKEN` secret to the reusable workflow for secure code coverage reporting.