### PR TITLE
Replace Locator.Current with AppLocator.Current for service resolution

### DIFF
--- a/src/ReactiveUI.Validation.AndroidX/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation.AndroidX/Extensions/ViewForExtensions.cs
@@ -54,7 +54,7 @@ public static class ViewForExtensions
 
         ArgumentNullException.ThrowIfNull(viewProperty);
 
-        formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+        formatter ??= AppLocator.Current.GetService<IValidationTextFormatter<string>>() ??
                       SingleLineFormatter.Default;
 
         return ValidationBinding.ForProperty(
@@ -94,7 +94,7 @@ public static class ViewForExtensions
 
         ArgumentNullException.ThrowIfNull(viewProperty);
 
-        formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+        formatter ??= AppLocator.Current.GetService<IValidationTextFormatter<string>>() ??
                       SingleLineFormatter.Default;
 
         return ValidationBinding.ForValidationHelperProperty(

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -56,7 +56,7 @@ public abstract class ReactiveValidationObject : ReactiveObject, IValidatableVie
         IValidationTextFormatter<string>? formatter = null)
     {
         _formatter = formatter ??
-                     Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+                     AppLocator.Current.GetService<IValidationTextFormatter<string>>() ??
                      SingleLineFormatter.Default;
 
         ValidationContext = new ValidationContext(scheduler);

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -75,7 +75,7 @@ public sealed class ValidationBinding : IValidationBinding
             throw new ArgumentNullException(nameof(viewProperty));
         }
 
-        formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+        formatter ??= AppLocator.Current.GetService<IValidationTextFormatter<string>>() ??
                       SingleLineFormatter.Default;
 
         var vcObs = view
@@ -193,7 +193,7 @@ public sealed class ValidationBinding : IValidationBinding
             throw new ArgumentNullException(nameof(viewProperty));
         }
 
-        formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+        formatter ??= AppLocator.Current.GetService<IValidationTextFormatter<string>>() ??
                       SingleLineFormatter.Default;
 
         var vcObs = view
@@ -356,7 +356,7 @@ public sealed class ValidationBinding : IValidationBinding
             throw new ArgumentNullException(nameof(viewProperty));
         }
 
-        formatter ??= Locator.Current.GetService<IValidationTextFormatter<string>>() ??
+        formatter ??= AppLocator.Current.GetService<IValidationTextFormatter<string>>() ??
                       SingleLineFormatter.Default;
 
         var vcObs = view


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

Updated service resolution in validation-related classes to use AppLocator.Current instead of Locator.Current when retrieving IValidationTextFormatter<string> instances. This change ensures consistency and potentially improved configurability in how services are located within the application.

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

