### PR TITLE
fix: migrate validation to ReactiveUI primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,239 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+This project uses **Microsoft Testing Platform (MTP)** with the **TUnit** testing framework. Test commands differ significantly from traditional VSTest.
+
+See: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?tabs=dotnet-test-with-mtp
+
+### Prerequisites
+
+```powershell
+# Check .NET installation
+dotnet --info
+
+# Restore NuGet packages
+dotnet restore ReactiveUI.Validation.slnx
+```
+
+**Note**: This repository uses **SLNX** (XML-based solution format) instead of the legacy SLN format.
+
+### Build Commands
+
+**CRITICAL:** The working folder must be `./src` folder. These commands won't function properly without the correct working folder.
+
+```powershell
+# Build the solution
+dotnet build ReactiveUI.Validation.slnx -c Release
+
+# Build with warnings as errors (includes StyleCop violations)
+dotnet build ReactiveUI.Validation.slnx -c Release -warnaserror
+
+# Clean the solution
+dotnet clean ReactiveUI.Validation.slnx
+```
+
+### Test Commands (Microsoft Testing Platform)
+
+**CRITICAL:** This repository uses MTP configured in `global.json`. All TUnit-specific arguments must be passed after `--`:
+
+The working folder must be `./src` folder. These commands won't function properly without the correct working folder.
+
+**IMPORTANT:**
+- Do NOT use `--no-build` flag when running tests. Always build before testing to ensure all code changes (including test changes) are compiled. Using `--no-build` can cause tests to run against stale binaries and produce misleading results.
+- Use `--output Detailed` to see Console.WriteLine output from tests. This must be placed BEFORE any `--` separator:
+  ```powershell
+  dotnet test --output Detailed -- --treenode-filter "..."
+  ```
+
+```powershell
+# Run all tests in the solution
+dotnet test --solution ReactiveUI.Validation.slnx -c Release
+
+# Run all tests in a specific project
+dotnet test --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -c Release
+
+# Run a single test method using treenode-filter
+# Syntax: /{AssemblyName}/{Namespace}/{ClassName}/{TestMethodName}
+dotnet test --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -- --treenode-filter "/*/*/*/MyTestMethod"
+
+# Run all tests in a specific class
+dotnet test --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -- --treenode-filter "/*/*/MyClassName/*"
+
+# Run tests in a specific namespace
+dotnet test --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -- --treenode-filter "/*/MyNamespace/*/*"
+
+# Filter by test property (e.g., Category)
+dotnet test --solution ReactiveUI.Validation.slnx -- --treenode-filter "/*/*/*/*[Category=Integration]"
+
+# Run tests with code coverage (Microsoft Code Coverage)
+dotnet test --solution ReactiveUI.Validation.slnx -- --coverage --coverage-output-format cobertura
+
+# Run tests with detailed output
+dotnet test --solution ReactiveUI.Validation.slnx -- --output Detailed
+
+# List all available tests without running them
+dotnet test --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -- --list-tests
+
+# Fail fast (stop on first failure)
+dotnet test --solution ReactiveUI.Validation.slnx -- --fail-fast
+
+# Control parallel test execution
+dotnet test --solution ReactiveUI.Validation.slnx -- --maximum-parallel-tests 4
+
+# Generate TRX report
+dotnet test --solution ReactiveUI.Validation.slnx -- --report-trx
+
+# Disable logo for cleaner output
+dotnet test --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -- --disable-logo
+
+# Combine options: coverage + TRX report + detailed output
+dotnet test --solution ReactiveUI.Validation.slnx -- --coverage --coverage-output-format cobertura --report-trx --output Detailed
+```
+
+**Alternative: Using `dotnet run` for single project**
+```powershell
+# Run tests using dotnet run (easier for passing flags)
+dotnet run --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -c Release -- --treenode-filter "/*/*/*/MyTest"
+
+# Disable logo for cleaner output
+dotnet run --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -- --disable-logo --treenode-filter "/*/*/*/Test1"
+```
+
+### TUnit Treenode-Filter Syntax
+
+The `--treenode-filter` follows the pattern: `/{AssemblyName}/{Namespace}/{ClassName}/{TestMethodName}`
+
+**Examples:**
+- Single test: `--treenode-filter "/*/*/*/MyTestMethod"`
+- All tests in class: `--treenode-filter "/*/*/MyClassName/*"`
+- All tests in namespace: `--treenode-filter "/*/MyNamespace/*/*"`
+- Filter by property: `--treenode-filter "/*/*/*/*[Category=Integration]"`
+- Multiple wildcards: `--treenode-filter "/*/*/MyTests*/*"`
+
+**Note:** Use single asterisks (`*`) to match segments. Double asterisks (`/**`) are not supported in treenode-filter.
+
+### Key TUnit Command-Line Flags
+
+- `--treenode-filter` - Filter tests by path pattern or properties (syntax: `/{Assembly}/{Namespace}/{Class}/{Method}`)
+- `--list-tests` - Display available tests without running
+- `--fail-fast` - Stop after first failure
+- `--maximum-parallel-tests` - Limit concurrent execution (default: processor count)
+- `--coverage` - Enable Microsoft Code Coverage
+- `--coverage-output-format` - Set coverage format (cobertura, xml, coverage)
+- `--report-trx` - Generate TRX format reports
+- `--output` - Control verbosity (Normal or Detailed)
+- `--no-progress` - Suppress progress reporting
+- `--disable-logo` - Remove TUnit logo display
+- `--diagnostic` - Enable diagnostic logging (Trace level)
+- `--timeout` - Set global test timeout
+
+See https://tunit.dev/docs/reference/command-line-flags for complete TUnit flag reference.
+
+### Code Coverage Reports
+
+To generate and view a code coverage report:
+
+```powershell
+# 1. Clean bin/obj to ensure fresh instrumentation
+find . -type d \( -name bin -o -name obj \) -exec rm -rf {} + 2>/dev/null
+
+# 2. Run tests with coverage
+dotnet test --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -c Release -- --coverage --coverage-output-format cobertura --disable-logo --no-progress
+
+# 3. Generate a text summary (requires dotnet-reportgenerator-globaltool)
+reportgenerator -reports:"tests/ReactiveUI.Validation.Tests/bin/Release/net10.0/TestResults/*.cobertura.xml" -targetdir:/tmp/coverage-report -reporttypes:TextSummary
+cat /tmp/coverage-report/Summary.txt
+
+# 4. Generate an HTML report for detailed per-file analysis
+reportgenerator -reports:"tests/ReactiveUI.Validation.Tests/bin/Release/net10.0/TestResults/*.cobertura.xml" -targetdir:/tmp/coverage-report -reporttypes:Html
+```
+
+**Note:** `Microsoft.Testing.Extensions.CodeCoverage` is pinned at 18.4.1 due to a regression in newer versions that produces incorrect coverage data. Do not upgrade without verifying coverage output.
+
+### Key Configuration Files
+
+- `global.json` - Specifies `"Microsoft.Testing.Platform"` as the test runner
+- `testconfig.json` - Configures test execution (`"parallel": true`) and code coverage (Cobertura format)
+- `Directory.Build.props` - Enables `TestingPlatformDotnetTestSupport` for test projects
+
+## Architecture Overview
+
+ReactiveUI.Validation is a validation library for ReactiveUI applications, providing a fluent API for defining and binding validation rules to view models and views.
+
+### Project Structure
+
+- `ReactiveUI.Validation/` - Core validation library
+- `ReactiveUI.Validation.AndroidX/` - Android-specific extensions
+- `tests/ReactiveUI.Validation.Tests/` - Unit tests
+
+### Core Concepts
+
+- **`ValidationContext`** - Container that aggregates multiple validation components
+- **`BasePropertyValidation<TViewModel, TValue>`** - Validates a single view model property
+- **`ObservableValidation<TViewModel, TValue>`** - Observable-based validation component
+- **`ValidationHelper`** - Bindable wrapper around a `ValidationContext` or single rule
+- **`ValidationText`** - Immutable collection of error message strings
+- **`IValidationState`** - Represents valid/invalid state with associated text
+
+### Extension Methods
+
+- `vm.ValidationRule(...)` - Attach a validation rule to a view model
+- `view.BindValidation(...)` - Bind validation errors to a view property
+- `vm.IsValid()` - Observable stream of validity changes
+- `vm.ClearValidationRules(...)` - Remove attached rules
+
+### Key Patterns
+
+**Defining rules on a view model:**
+```csharp
+this.ValidationRule(
+    vm => vm.Name,
+    name => !string.IsNullOrWhiteSpace(name),
+    "Name should not be empty.");
+```
+
+**Binding to a view:**
+```csharp
+this.BindValidation(ViewModel, vm => vm.Name, v => v.NameErrorLabel);
+```
+
+**Observable-based rules:**
+```csharp
+this.ValidationRule(
+    vm => vm.Name,
+    this.WhenAnyValue(x => x.Name, x => x.Name2, (a, b) => a == b),
+    "Names must match.");
+```
+
+## Code Style & Quality Requirements
+
+**CRITICAL:** All code must comply with ReactiveUI contribution guidelines: https://www.reactiveui.net/contribute/index.html
+
+### Style Enforcement
+
+- EditorConfig rules (`.editorconfig`) - comprehensive C# formatting and naming conventions
+- StyleCop Analyzers - builds fail on violations
+- Roslynator Analyzers - additional code quality rules
+- **All public APIs require XML documentation comments**
+
+### C# Style Rules
+
+- **Braces:** Allman style (each brace on new line)
+- **Indentation:** 4 spaces, no tabs
+- **Fields:** `_camelCase` for private/internal, `readonly` where possible
+- **Visibility:** Always explicit, visibility first modifier
+- **Namespaces:** File-scoped preferred, imports outside namespace
+- **Modern C#:** Use nullable reference types, pattern matching, file-scoped namespaces
+
+## Testing Guidelines
+
+- Unit tests use **TUnit** framework with **Microsoft Testing Platform**
+- Test projects detected via `IsTestProject` MSBuild property
+- Coverage configured in `testconfig.json` (Cobertura format, skip auto-properties)
+- Parallel test execution enabled (`"parallel": true` in testconfig.json)
+- Always write unit tests for new features or bug fixes
+- Follow existing test patterns in `tests/ReactiveUI.Validation.Tests/`
+- API approval tests use **Verify.TUnit** — run tests to regenerate `.verified.txt` files when the public API changes

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -38,6 +38,7 @@
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <IsPackable>false</IsPackable>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsSampleProject)' == 'true'">

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,19 +5,20 @@
   </PropertyGroup>
 
   <ItemGroup Label="Core packages">
-    <PackageVersion Include="ReactiveUI" Version="23.2.28" />
-    <PackageVersion Include="ReactiveUI.AndroidX" Version="23.2.28" />
-    <PackageVersion Include="Splat" Version="19.4.1" />
-    <PackageVersion Include="Splat.Builder" Version="19.4.1" />
-    <PackageVersion Include="Polyfill" Version="10.8.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.8" />
-    <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.14.0" />
-    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="2.10.0.2" />
-    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.10.0.2" />
-    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" Version="2.10.0.2" />
-    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.10.0.2" />
-    <PackageVersion Include="Xamarin.AndroidX.SavedState.SavedState.Ktx" Version="1.5.0" />
-    <PackageVersion Include="Xamarin.AndroidX.Activity.Ktx" Version="1.13.0" />
+    <PackageVersion Include="DynamicData" Version="9.4.32" />
+    <PackageVersion Include="ReactiveUI" Version="24.0.0-beta.2" />
+    <PackageVersion Include="ReactiveUI.AndroidX" Version="24.0.0-beta.2" />
+    <PackageVersion Include="Splat" Version="20.0.0" />
+    <PackageVersion Include="Splat.Builder" Version="20.0.0" />
+    <PackageVersion Include="Polyfill" Version="10.11.2" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.9" />
+    <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.14.0.3" />
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="2.11.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.11.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Runtime.Ktx" Version="2.11.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.11.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.SavedState.SavedState.Ktx" Version="1.5.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Activity.Ktx" Version="1.13.0.1" />
   </ItemGroup>
 
   <ItemGroup Label="Build tools">
@@ -28,11 +29,11 @@
   </ItemGroup>
 
   <ItemGroup Label="Test packages">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
-    <PackageVersion Include="TUnit" Version="1.53.0" />
-    <PackageVersion Include="Verify.TUnit" Version="31.19.0" />
+    <PackageVersion Include="TUnit" Version="1.57.0" />
+    <PackageVersion Include="Verify.TUnit" Version="31.20.0" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Validation.slnx
+++ b/src/ReactiveUI.Validation.slnx
@@ -6,6 +6,7 @@
     <File Path="../version.json" />
     <File Path="Directory.build.props" />
     <File Path="Directory.build.targets" />
+    <File Path="Directory.Packages.props" />
     <File Path="stylecop.json" />
   </Folder>
   <Project Path="ReactiveUI.Validation.AndroidX/ReactiveUI.Validation.AndroidX.csproj" />
@@ -13,6 +14,7 @@
   <Project Path="tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj" />
   <Folder Name="/Samples/">
     <Project Path="samples/AvaloniaApplication1/AvaloniaApplication1.csproj" />
+    <File Path="samples/Directory.Packages.props" />
     <Project Path="samples/AvaloniaApplication1.Desktop/AvaloniaApplication1.Desktop.csproj" />
     <Project Path="samples/LoginApp/LoginApp.csproj" />
     <Project Path="samples/LoginApp.Avalonia/LoginApp.Avalonia.csproj" />

--- a/src/ReactiveUI.Validation/Collections/ArrayValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ArrayValidationText.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections;
-using System.Collections.Generic;
 
 namespace ReactiveUI.Validation.Collections;
 

--- a/src/ReactiveUI.Validation/Collections/IValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/IValidationText.cs
@@ -3,8 +3,6 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-
 namespace ReactiveUI.Validation.Collections;
 
 /// <summary>

--- a/src/ReactiveUI.Validation/Collections/ReadOnlyDisposableCollection{T}.cs
+++ b/src/ReactiveUI.Validation/Collections/ReadOnlyDisposableCollection{T}.cs
@@ -3,9 +3,7 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace ReactiveUI.Validation.Collections;

--- a/src/ReactiveUI.Validation/Collections/SingleValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/SingleValidationText.cs
@@ -3,9 +3,7 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 
 namespace ReactiveUI.Validation.Collections;
 

--- a/src/ReactiveUI.Validation/Collections/ValidationText.cs
+++ b/src/ReactiveUI.Validation/Collections/ValidationText.cs
@@ -3,10 +3,7 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace ReactiveUI.Validation.Collections;
 

--- a/src/ReactiveUI.Validation/Comparators/ValidationStateComparer.cs
+++ b/src/ReactiveUI.Validation/Comparators/ValidationStateComparer.cs
@@ -3,8 +3,6 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using ReactiveUI.Validation.States;
 
 namespace ReactiveUI.Validation.Comparators;

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidatesProperties.cs
@@ -1,9 +1,7 @@
-﻿// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // Licensed to the ReactiveUI and Contributors under one or more agreements.
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
-
-using System.Collections.Generic;
 
 namespace ReactiveUI.Validation.Components.Abstractions;
 

--- a/src/ReactiveUI.Validation/Components/Abstractions/IValidationComponent.cs
+++ b/src/ReactiveUI.Validation/Components/Abstractions/IValidationComponent.cs
@@ -3,7 +3,6 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.States;
 

--- a/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
+++ b/src/ReactiveUI.Validation/Components/BasePropertyValidation.cs
@@ -3,15 +3,8 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reactive.Disposables;
-using System.Reactive.Disposables.Fluent;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Comparators;
@@ -31,7 +24,7 @@ public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisp
     /// <summary>
     /// Replays the latest validity boolean to subscribers.
     /// </summary>
-    private readonly ReplaySubject<bool> _isValidSubject = new(1);
+    private readonly ReplaySignal<bool> _isValidSubject = new(1);
 
     /// <summary>
     /// Tracks property names this validation monitors.
@@ -46,7 +39,7 @@ public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisp
     /// <summary>
     /// The connected observable that multicasts validation state changes.
     /// </summary>
-    private IConnectableObservable<IValidationState>? _connectedChange;
+    private ConnectableSignal<IValidationState>? _connectedChange;
 
     /// <summary>
     /// Tracks whether <see cref="Activate"/> has been called.
@@ -58,7 +51,7 @@ public abstract class BasePropertyValidation<TViewModel> : ReactiveObject, IDisp
     /// Subscribe to the valid subject so we can assign the validity.
     /// </summary>
     protected BasePropertyValidation() =>
-        _isValidSubject.Subscribe(v => IsValid = v).DisposeWith(_disposables);
+      SubscribeExtensions.Subscribe(_isValidSubject, v => IsValid = v).DisposeWith(_disposables);
 
     /// <inheritdoc/>
     public int PropertyCount => _propertyNames.Count;
@@ -188,12 +181,12 @@ public sealed class BasePropertyValidation<TViewModel, TViewModelProperty> : Bas
     /// <summary>
     /// Replays the latest property value to subscribers.
     /// </summary>
-    private readonly ReplaySubject<TViewModelProperty?> _valueSubject = new(1);
+    private readonly ReplaySignal<TViewModelProperty?> _valueSubject = new(1);
 
     /// <summary>
     /// The connected observable that multicasts property value changes.
     /// </summary>
-    private readonly IConnectableObservable<TViewModelProperty?> _valueConnectedObservable;
+    private readonly ConnectableSignal<TViewModelProperty?> _valueConnectedObservable;
 
     /// <summary>
     /// The function that produces validation text from the property value and validity.

--- a/src/ReactiveUI.Validation/Components/ObservableValidationBase{TViewModel,TValue}.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidationBase{TViewModel,TValue}.cs
@@ -1,16 +1,9 @@
-﻿// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // Licensed to the ReactiveUI and Contributors under one or more agreements.
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reactive.Disposables;
-using System.Reactive.Disposables.Fluent;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.Extensions;
@@ -28,7 +21,7 @@ public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObj
     /// <summary>
     /// Replays the latest validation state to subscribers.
     /// </summary>
-    private readonly ReplaySubject<IValidationState> _isValidSubject = new(1);
+    private readonly ReplaySignal<IValidationState> _isValidSubject = new(1);
 
     /// <summary>
     /// Tracks property names this validation monitors.
@@ -43,7 +36,7 @@ public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObj
     /// <summary>
     /// The connected observable that multicasts validation state changes.
     /// </summary>
-    private readonly IConnectableObservable<IValidationState> _validityConnectedObservable;
+    private readonly ConnectableSignal<IValidationState> _validityConnectedObservable;
 
     /// <summary>
     /// Tracks whether <see cref="Activate"/> has been called.
@@ -62,7 +55,7 @@ public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObj
         IObservable<TValue> observable,
         Func<TViewModel, TValue, bool> isValidFunc,
         Func<TViewModel, TValue, bool, IValidationText> messageFunc)
-        : this(observable.Select(value =>
+        : this((observable ?? throw new ArgumentNullException(nameof(observable))).Select(value =>
         {
             var isValid = isValidFunc(viewModel, value);
             var message = messageFunc(viewModel, value, isValid);
@@ -77,14 +70,13 @@ public abstract class ObservableValidationBase<TViewModel, TValue> : ReactiveObj
     /// <param name="observable">Observable that updates the view model property validity.</param>
     protected ObservableValidationBase(IObservable<IValidationState> observable)
     {
-        _isValidSubject
-            .Do(state =>
-            {
-                IsValid = state.IsValid;
-                Text = state.Text;
-            })
-            .Subscribe()
-            .DisposeWith(_disposables);
+        SubscribeExtensions.Subscribe(_isValidSubject
+             .Do(state =>
+             {
+                 IsValid = state.IsValid;
+                 Text = state.Text;
+             }))
+             .DisposeWith(_disposables);
 
         _validityConnectedObservable = Observable
             .Defer(() => observable)

--- a/src/ReactiveUI.Validation/Components/ObservableValidation{TViewModel,TValue,TProp}.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation{TViewModel,TValue,TProp}.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // Licensed to the ReactiveUI and Contributors under one or more agreements.
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Linq.Expressions;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.States;

--- a/src/ReactiveUI.Validation/Components/ObservableValidation{TViewModel,TValue}.cs
+++ b/src/ReactiveUI.Validation/Components/ObservableValidation{TViewModel,TValue}.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // Licensed to the ReactiveUI and Contributors under one or more agreements.
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.States;
 

--- a/src/ReactiveUI.Validation/Contexts/IValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/IValidationContext.cs
@@ -1,18 +1,15 @@
-﻿// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // Licensed to the ReactiveUI and Contributors under one or more agreements.
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Reactive.Disposables;
 using DynamicData;
 using ReactiveUI.Validation.Components.Abstractions;
 
 namespace ReactiveUI.Validation.Contexts;
 
 /// <inheritdoc cref="IReactiveObject" />
-/// <inheritdoc cref="ICancelable" />
+/// <inheritdoc cref="IsDisposed" />
 /// <inheritdoc cref="IValidationComponent" />
 /// <summary>
 /// The overall context for a view model under which validation takes place.
@@ -21,7 +18,7 @@ namespace ReactiveUI.Validation.Contexts;
 /// Contains all of the <see cref="IValidationComponent" /> instances
 /// applicable to the view model.
 /// </remarks>
-public interface IValidationContext : IValidationComponent, IReactiveObject, ICancelable
+public interface IValidationContext : IValidationComponent, IReactiveObject, IsDisposed
 {
     /// <summary>
     /// Gets an observable for the Valid state.

--- a/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
+++ b/src/ReactiveUI.Validation/Contexts/ValidationContext.cs
@@ -3,19 +3,10 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Disposables.Fluent;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
-
 using DynamicData;
-
+using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.States;
@@ -42,12 +33,12 @@ public class ValidationContext : ReactiveObject, IValidationContext
     /// <summary>
     /// Replays the latest validation state to subscribers of <see cref="ValidationStatusChange"/>.
     /// </summary>
-    private readonly ReplaySubject<IValidationState> _validationStatusChange = new(1);
+    private readonly ReplaySignal<IValidationState> _validationStatusChange = new(1);
 
     /// <summary>
     /// Replays the latest overall validity boolean to subscribers of <see cref="Valid"/>.
     /// </summary>
-    private readonly ReplaySubject<bool> _validSubject = new(1);
+    private readonly ReplaySignal<bool> _validSubject = new(1);
 
     /// <summary>
     /// The observable that computes the aggregate validity of all validation components.
@@ -81,7 +72,7 @@ public class ValidationContext : ReactiveObject, IValidationContext
     [RequiresUnreferencedCode("WhenAnyValue may reference members that could be trimmed in AOT scenarios.")]
     public ValidationContext(IScheduler? scheduler = null)
     {
-        scheduler ??= CurrentThreadScheduler.Instance;
+        scheduler ??= CurrentThreadSequencer.Instance;
         var changeSets = _validationSource.Connect().ObserveOn(scheduler);
         Validations = changeSets.AsObservableList();
 
@@ -96,20 +87,17 @@ public class ValidationContext : ReactiveObject, IValidationContext
 
         _isValid = _validSubject
             .StartWith(true)
-            .ToProperty(this, m => m.IsValid, scheduler: scheduler)
-            .DisposeWith(_disposables);
+            .ToProperty(this, m => m.IsValid, scheduler: scheduler);
 
         _validationText = _validSubject
             .StartWith(true)
             .Select(_ => BuildText())
-            .ToProperty(this, m => m.Text, ValidationText.None, scheduler: scheduler)
-            .DisposeWith(_disposables);
+            .ToProperty(this, m => m.Text, ValidationText.None, scheduler: scheduler);
 
-        _validSubject
-            .Select(_ => new ValidationState(IsValid, BuildText()))
-            .Do(_validationStatusChange.OnNext)
-            .Subscribe()
-            .DisposeWith(_disposables);
+        SubscribeExtensions.Subscribe(_validSubject
+             .Select(_ => new ValidationState(IsValid, BuildText()))
+             .Do(_validationStatusChange.OnNext))
+             .DisposeWith(_disposables);
     }
 
     /// <summary>

--- a/src/ReactiveUI.Validation/Extensions/ArrayPoolExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ArrayPoolExtensions.cs
@@ -3,7 +3,6 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Buffers;
 
 namespace ReactiveUI.Validation.Extensions;

--- a/src/ReactiveUI.Validation/Extensions/ExpressionExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ExpressionExtensions.cs
@@ -3,8 +3,6 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace ReactiveUI.Validation.Extensions;

--- a/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatableViewModelExtensions.cs
@@ -3,18 +3,13 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Components;
 using ReactiveUI.Validation.Components.Abstractions;
 using ReactiveUI.Validation.Contexts;
-using ReactiveUI.Validation.Helpers;
 using ReactiveUI.Validation.States;
 
 namespace ReactiveUI.Validation.Extensions;

--- a/src/ReactiveUI.Validation/Extensions/ValidatesPropertiesExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidatesPropertiesExtensions.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // Licensed to the ReactiveUI and Contributors under one or more agreements.
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Linq.Expressions;
 using ReactiveUI.Validation.Components.Abstractions;
 

--- a/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ValidationContextExtensions.cs
@@ -3,11 +3,7 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reactive.Linq;
 using DynamicData;
 using ReactiveUI.Validation.Components;
 using ReactiveUI.Validation.Components.Abstractions;
@@ -52,12 +48,12 @@ public static class ValidationContextExtensions
             .Validations
             .Connect()
             .ToCollection()
-            .Select(validations => validations
-                .OfType<IPropertyValidationComponent>()
-                .Where(validation => validation.ContainsPropertyName(propertyName, strict))
-                .Select(validation => validation.ValidationStatusChange)
-                .CombineLatest()
-                .StartWith(InitialValidationStates))
+            .Select(validations =>
+                System.Reactive.Linq.Observable.CombineLatest(validations
+                    .OfType<IPropertyValidationComponent>()
+                    .Where(validation => validation.ContainsPropertyName(propertyName, strict))
+                    .Select(validation => validation.ValidationStatusChange))
+                    .StartWith(InitialValidationStates))
             .Switch();
     }
 }

--- a/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
+++ b/src/ReactiveUI.Validation/Extensions/ViewForExtensions.cs
@@ -3,13 +3,11 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Formatters;
 using ReactiveUI.Validation.Formatters.Abstractions;
-using ReactiveUI.Validation.Helpers;
 using ReactiveUI.Validation.ValidationBindings;
 
 namespace ReactiveUI.Validation.Extensions;

--- a/src/ReactiveUI.Validation/Helpers/ArgumentExceptionHelper.cs
+++ b/src/ReactiveUI.Validation/Helpers/ArgumentExceptionHelper.cs
@@ -3,8 +3,6 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -44,7 +44,7 @@ public abstract class ReactiveValidationObject : ReactiveObject, IValidatableVie
     /// Initializes a new instance of the <see cref="ReactiveValidationObject"/> class.
     /// </summary>
     /// <param name="scheduler">
-    /// Scheduler for the <see cref="ValidationContext"/>. Uses <see cref="CurrentThreadScheduler"/> by default.
+    /// Scheduler for the <see cref="ValidationContext"/>. Uses <see cref="ReactiveUI.Primitives.Concurrency.CurrentThreadSequencer"/> by default.
     /// </param>
     /// <param name="formatter">
     /// Validation formatter. Defaults to <see cref="SingleLineFormatter"/>. In order to override the global

--- a/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
+++ b/src/ReactiveUI.Validation/Helpers/ReactiveValidationObject.cs
@@ -3,19 +3,10 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
-using System.Reactive.Disposables.Fluent;
-using System.Reactive.Linq;
-
 using DynamicData;
-
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Components.Abstractions;
@@ -71,7 +62,8 @@ public abstract class ReactiveValidationObject : ReactiveObject, IValidatableVie
 
         ValidationContext = new ValidationContext(scheduler);
         ValidationContext.DisposeWith(_disposables);
-        ValidationContext.Validations
+        SubscribeExtensions.Subscribe(
+            ValidationContext.Validations
             .Connect()
             .ToCollection()
             .Select(components => components
@@ -80,8 +72,8 @@ public abstract class ReactiveValidationObject : ReactiveObject, IValidatableVie
                     .Select(_ => component))
                 .Merge()
                 .StartWith(ValidationContext))
-            .Switch()
-            .Subscribe(OnValidationStatusChange).DisposeWith(_disposables);
+            .Switch(),
+            OnValidationStatusChange).DisposeWith(_disposables);
     }
 
     /// <inheritdoc />

--- a/src/ReactiveUI.Validation/Helpers/ValidationHelper.cs
+++ b/src/ReactiveUI.Validation/Helpers/ValidationHelper.cs
@@ -3,9 +3,7 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive.Linq;
 
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Components.Abstractions;

--- a/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
+++ b/src/ReactiveUI.Validation/ReactiveUI.Validation.csproj
@@ -6,10 +6,19 @@
 
   <ItemGroup>
     <PackageReference Include="ReactiveUI" />
+    <PackageReference Include="DynamicData" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="ReactiveUI.Validation.Helpers" />
+    <Using Include="ReactiveUI.Primitives" />
+    <Using Include="ReactiveUI.Primitives.Disposables" />
+    <Using Include="ReactiveUI.Primitives.Signals" />
+    <Using Include="ReactiveUI.Primitives.Disposables.Scope" Alias="Disposable" />
+    <Using Include="ReactiveUI.Primitives.Concurrency.ISequencer" Alias="IScheduler" />
+    <Using Include="ReactiveUI.Primitives.Signals.Signal" Alias="Observable" />
+    <Using Include="ReactiveUI.Primitives.RxVoid" Alias="Unit" />
+    <Using Include="ReactiveUI.Primitives.Disposables.MultipleDisposable" Alias="CompositeDisposable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.Validation/States/IValidationState.cs
+++ b/src/ReactiveUI.Validation/States/IValidationState.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // Licensed to the ReactiveUI and Contributors under one or more agreements.
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using ReactiveUI.Validation.Collections;
 
 namespace ReactiveUI.Validation.States;

--- a/src/ReactiveUI.Validation/States/ValidationState.cs
+++ b/src/ReactiveUI.Validation/States/ValidationState.cs
@@ -3,7 +3,6 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using ReactiveUI.Validation.Collections;
 
 namespace ReactiveUI.Validation.States;

--- a/src/ReactiveUI.Validation/ValidationBindings/Abstractions/IValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/Abstractions/IValidationBinding.cs
@@ -3,8 +3,6 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-
 namespace ReactiveUI.Validation.ValidationBindings.Abstractions;
 
 /// <summary>

--- a/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
+++ b/src/ReactiveUI.Validation/ValidationBindings/ValidationBinding.cs
@@ -3,19 +3,13 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reactive;
-using System.Reactive.Linq;
 
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Formatters;
 using ReactiveUI.Validation.Formatters.Abstractions;
-using ReactiveUI.Validation.Helpers;
 using ReactiveUI.Validation.States;
 using ReactiveUI.Validation.ValidationBindings.Abstractions;
 
@@ -35,7 +29,7 @@ public sealed class ValidationBinding : IValidationBinding
     /// Initializes a new instance of the <see cref="ValidationBinding"/> class.
     /// </summary>
     /// <param name="bindingObservable">The observable that drives the validation binding updates.</param>
-    internal ValidationBinding(IObservable<Unit> bindingObservable) => _disposable = bindingObservable.Subscribe();
+    internal ValidationBinding(IObservable<Unit> bindingObservable) => _disposable = SubscribeExtensions.Subscribe(bindingObservable);
 
     /// <summary>
     /// Creates a binding between a ViewModel property and a view property.

--- a/src/samples/AvaloniaApplication1.Desktop/Program.cs
+++ b/src/samples/AvaloniaApplication1.Desktop/Program.cs
@@ -6,7 +6,6 @@
 using System;
 
 using Avalonia;
-using Avalonia.ReactiveUI;
 
 namespace AvaloniaApplication1.Desktop;
 
@@ -24,6 +23,5 @@ internal static class Program
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
-            .LogToTrace()
-            .UseReactiveUI();
+            .LogToTrace();
 }

--- a/src/samples/AvaloniaApplication1/AvaloniaApplication1.csproj
+++ b/src/samples/AvaloniaApplication1/AvaloniaApplication1.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
-    <PackageReference Include="ReactiveUI.Avalonia" />
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
   </ItemGroup>
 </Project>

--- a/src/samples/Directory.Packages.props
+++ b/src/samples/Directory.Packages.props
@@ -1,16 +1,15 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.3" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.3" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.3" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="14.7.1" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.3" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.17" />
+    <PackageVersion Include="Avalonia" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.18" />
     <PackageVersion Include="MessageBox.Avalonia" Version="12.0.0" />
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.1.0" />
     <PackageVersion Include="MahApps.Metro" Version="2.4.11" />
-    <PackageVersion Include="ReactiveUI.WPF" Version="23.2.28" />
-    <PackageVersion Include="ReactiveUI.WinForms" Version="23.2.28" />
+    <PackageVersion Include="ReactiveUI.WPF" Version="24.0.0-beta.2" />
+    <PackageVersion Include="ReactiveUI.WinForms" Version="24.0.0-beta.2" />
   </ItemGroup>
 </Project>

--- a/src/samples/LoginApp.Avalonia.Desktop/Program.cs
+++ b/src/samples/LoginApp.Avalonia.Desktop/Program.cs
@@ -6,7 +6,6 @@
 using System;
 
 using Avalonia;
-using Avalonia.ReactiveUI;
 
 namespace LoginApp.Avalonia.Desktop;
 
@@ -27,6 +26,5 @@ internal static class Program
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
-            .LogToTrace()
-            .UseReactiveUI();
+            .LogToTrace();
 }

--- a/src/samples/LoginApp.Avalonia/LoginApp.Avalonia.csproj
+++ b/src/samples/LoginApp.Avalonia/LoginApp.Avalonia.csproj
@@ -14,7 +14,6 @@
 		<PackageReference Include="Avalonia" />
 		<PackageReference Include="Avalonia.Themes.Fluent" />
 		<PackageReference Include="Avalonia.Fonts.Inter" />
-		<PackageReference Include="ReactiveUI.Avalonia" />
 		<PackageReference Include="MessageBox.Avalonia" />
 		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
 	</ItemGroup>

--- a/src/samples/LoginApp.Avalonia/Views/SignUpView.axaml
+++ b/src/samples/LoginApp.Avalonia/Views/SignUpView.axaml
@@ -1,6 +1,8 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:LoginApp.ViewModels;assembly=LoginApp"
         x:Class="LoginApp.Avalonia.Views.SignUpView"
+        x:DataType="vm:SignUpViewModel"
         Width="400" Height="500">
 	<StackPanel Margin="10">
 		<Grid ColumnDefinitions="Auto, *">
@@ -10,30 +12,34 @@
                         Width="5" Height="5"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
+                        IsVisible="{Binding IsBusy}"
                         Fill="Red" Margin="7 7 5 3" />
 		</Grid>
 		<TextBox Margin="0 10 0 0"
                     x:Name="UserNameTextBox"
-                    Watermark="Please, enter user name..."
-                    UseFloatingWatermark="True" />
+                    PlaceholderText="Please, enter user name..."
+                    UseFloatingPlaceholder="True"
+                    Text="{Binding UserName, Mode=TwoWay}" />
 		<TextBlock x:Name="UserNameValidation"
                     Foreground="Red"
                     FontSize="12" />
 
 		<TextBox Margin="0 10 0 0"
                     x:Name="PasswordTextBox"
-                    Watermark="Please, enter your password..."
-                    UseFloatingWatermark="True"
-                    PasswordChar="*" />
+                    PlaceholderText="Please, enter your password..."
+                    UseFloatingPlaceholder="True"
+                    PasswordChar="*"
+                    Text="{Binding Password, Mode=TwoWay}" />
 		<TextBlock x:Name="PasswordValidation"
                     Foreground="Red"
                     FontSize="12" />
 
 		<TextBox Margin="0 10 0 0"
                     x:Name="ConfirmPasswordTextBox"
-                    Watermark="Please, confirm the password..."
-                    UseFloatingWatermark="True"
-                    PasswordChar="*" />
+                    PlaceholderText="Please, confirm the password..."
+                    UseFloatingPlaceholder="True"
+                    PasswordChar="*"
+                    Text="{Binding ConfirmPassword, Mode=TwoWay}" />
 		<TextBlock x:Name="ConfirmPasswordValidation"
                     TextWrapping="Wrap"
                     Foreground="Red"
@@ -41,7 +47,8 @@
 
 		<Button Margin="0 10 0 5"
                 Content="Sign up"
-                x:Name="SignUpButton" />
+                x:Name="SignUpButton"
+                Command="{Binding SignUp}" />
 		<TextBlock x:Name="CompoundValidation"
                     TextWrapping="Wrap"
                     Foreground="Red"

--- a/src/samples/LoginApp.Avalonia/Views/SignUpView.axaml.cs
+++ b/src/samples/LoginApp.Avalonia/Views/SignUpView.axaml.cs
@@ -4,13 +4,16 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Reactive.Disposables;
-using System.Reactive.Disposables.Fluent;
-using Avalonia.ReactiveUI;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
 using LoginApp.ViewModels;
 using ReactiveUI;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Formatters;
+using ReactiveUI.Validation.States;
 
 namespace LoginApp.Avalonia.Views;
 
@@ -18,46 +21,57 @@ namespace LoginApp.Avalonia.Views;
 /// A page which contains controls for signing up.
 /// </summary>
 /// <inheritdoc />
-public partial class SignUpView : ReactiveUserControl<SignUpViewModel>
+public partial class SignUpView : UserControl
 {
+    private readonly SingleLineFormatter _compoundFormatter = new(Environment.NewLine);
+    private MultipleDisposable? _validationBindings;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SignUpView"/> class.
     /// </summary>
     public SignUpView()
     {
         InitializeComponent();
-        this.WhenActivated(disposables =>
+        DataContextChanged += (_, _) => BindValidationMessages(DataContext as SignUpViewModel);
+        DetachedFromVisualTree += (_, _) => ClearValidationMessages();
+        BindValidationMessages(DataContext as SignUpViewModel);
+    }
+
+    private static string FormatPropertyMessages(IList<IValidationState> states) =>
+        states
+            .Select(state => SingleLineFormatter.Default.Format(state.Text))
+            .FirstOrDefault(static message => !string.IsNullOrEmpty(message)) ?? string.Empty;
+
+    private void BindValidationMessages(SignUpViewModel? viewModel)
+    {
+        ClearValidationMessages();
+        if (viewModel is null)
         {
-            // Standard ReactiveUI bindings.
-            this.Bind(ViewModel, x => x.UserName, x => x.UserNameTextBox.Text)
-                .DisposeWith(disposables);
-            this.Bind(ViewModel, x => x.Password, x => x.PasswordTextBox.Text)
-                .DisposeWith(disposables);
-            this.Bind(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordTextBox.Text)
-                .DisposeWith(disposables);
-            this.BindCommand(ViewModel, x => x.SignUp, x => x.SignUpButton)
-                .DisposeWith(disposables);
+            return;
+        }
 
-            this.OneWayBind(ViewModel, x => x.IsBusy, x => x.BudyIndicator.IsVisible)
-                .DisposeWith(disposables);
+        var disposables = new MultipleDisposable();
+        var validationContext = viewModel.ValidationContext;
 
-            // ReactiveUI.Validation: Bindings for error messages.
-            // BindValidation(ViewModel, vmProperty, viewControlProperty)
-            // This will bind the validation message for the specified property to the control property.
-            this.BindValidation(ViewModel, x => x.UserName, x => x.UserNameValidation.Text)
-                .DisposeWith(disposables);
-            this.BindValidation(ViewModel, x => x.Password, x => x.PasswordValidation.Text)
-                .DisposeWith(disposables);
-            this.BindValidation(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordValidation.Text)
-                .DisposeWith(disposables);
+        disposables.Add(SubscribeExtensions.Subscribe(
+            validationContext.ObserveFor<SignUpViewModel, string>(x => x.UserName),
+            states => UserNameValidation.Text = FormatPropertyMessages(states)));
+        disposables.Add(SubscribeExtensions.Subscribe(
+            validationContext.ObserveFor<SignUpViewModel, string>(x => x.Password),
+            states => PasswordValidation.Text = FormatPropertyMessages(states)));
+        disposables.Add(SubscribeExtensions.Subscribe(
+            validationContext.ObserveFor<SignUpViewModel, string>(x => x.ConfirmPassword),
+            states => ConfirmPasswordValidation.Text = FormatPropertyMessages(states)));
+        disposables.Add(SubscribeExtensions.Subscribe(
+            validationContext.ValidationStatusChange,
+            state => CompoundValidation.Text = _compoundFormatter.Format(state.Text)));
 
-            // ReactiveUI.Validation: Compound validation bindings.
-            // BindValidation(ViewModel, viewControlProperty)
-            // This will bind all validation messages for the entire ViewModel to the control property.
-            // We use a formatter to join multiple error messages with a new line.
-            var newLineFormatter = new SingleLineFormatter(Environment.NewLine);
-            this.BindValidation(ViewModel, x => x.CompoundValidation.Text, newLineFormatter)
-                .DisposeWith(disposables);
-        });
+        _validationBindings = disposables;
+    }
+
+    private void ClearValidationMessages()
+    {
+        _validationBindings?.Dispose();
+        _validationBindings = null;
     }
 }

--- a/src/samples/LoginApp.WinForms/Views/SignUpView.cs
+++ b/src/samples/LoginApp.WinForms/Views/SignUpView.cs
@@ -5,12 +5,11 @@
 
 using System;
 using System.ComponentModel;
-using System.Reactive.Disposables;
-using System.Reactive.Disposables.Fluent;
 using System.Windows.Forms;
 using LoginApp.ViewModels;
 using LoginApp.WinForms.Services;
 using ReactiveUI;
+using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Formatters;
 
@@ -27,34 +26,26 @@ public partial class SignUpView : Form, IViewFor<SignUpViewModel>
     public SignUpView()
     {
         InitializeComponent();
-        this.WhenActivated(disposables =>
+        this.WhenActivated((MultipleDisposable disposables) =>
         {
             // Standard ReactiveUI bindings.
-            this.Bind(ViewModel, x => x.UserName, x => x.UserNameTextBox.Text)
-                .DisposeWith(disposables);
-            this.Bind(ViewModel, x => x.Password, x => x.PasswordTextBox.Text)
-                .DisposeWith(disposables);
-            this.Bind(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordTextBox.Text)
-                .DisposeWith(disposables);
-            this.BindCommand(ViewModel, x => x.SignUp, x => x.SignUpButton)
-                .DisposeWith(disposables);
+            disposables.Add(this.Bind(ViewModel, x => x.UserName, x => x.UserNameTextBox.Text));
+            disposables.Add(this.Bind(ViewModel, x => x.Password, x => x.PasswordTextBox.Text));
+            disposables.Add(this.Bind(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordTextBox.Text));
+            disposables.Add(this.BindCommand(ViewModel, x => x.SignUp, x => x.SignUpButton));
 
             // ReactiveUI.Validation: Bindings for error messages.
             // BindValidation(ViewModel, vmProperty, viewControlProperty)
             // This will bind the validation message for the specified property to the control property.
-            this.BindValidation(ViewModel, x => x.UserName, x => x.UserNameErrorLabel.Text)
-                .DisposeWith(disposables);
-            this.BindValidation(ViewModel, x => x.Password, x => x.PasswordErrorLabel.Text)
-                .DisposeWith(disposables);
-            this.BindValidation(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordErrorLabel.Text)
-                .DisposeWith(disposables);
+            disposables.Add(this.BindValidation(ViewModel, x => x.UserName, x => x.UserNameErrorLabel.Text));
+            disposables.Add(this.BindValidation(ViewModel, x => x.Password, x => x.PasswordErrorLabel.Text));
+            disposables.Add(this.BindValidation(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordErrorLabel.Text));
 
             // ReactiveUI.Validation: Compound validation bindings.
             // BindValidation(ViewModel, viewControlProperty)
             // This will bind all validation messages for the entire ViewModel to the control property.
             // We use a formatter to join multiple error messages with a new line.
-            this.BindValidation(ViewModel, x => x.ErrorLabel.Text, new SingleLineFormatter(Environment.NewLine))
-                .DisposeWith(disposables);
+            disposables.Add(this.BindValidation(ViewModel, x => x.ErrorLabel.Text, new SingleLineFormatter(Environment.NewLine)));
         });
     }
 

--- a/src/samples/LoginApp.Wpf/Views/SignUpView.xaml.cs
+++ b/src/samples/LoginApp.Wpf/Views/SignUpView.xaml.cs
@@ -4,10 +4,9 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Reactive.Disposables;
-using System.Reactive.Disposables.Fluent;
 using LoginApp.ViewModels;
 using ReactiveUI;
+using ReactiveUI.Primitives.Disposables;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Formatters;
 
@@ -24,39 +23,35 @@ public partial class SignUpView : ReactiveUserControl<SignUpViewModel>
     public SignUpView()
     {
         InitializeComponent();
-        this.WhenActivated(disposables =>
+        this.WhenActivated((MultipleDisposable disposables) =>
         {
-            this.WhenAnyValue(x => x.ViewModel)
-                .BindTo(this, x => x.DataContext)
-                .DisposeWith(disposables);
+            disposables.Add(
+                this.WhenAnyValue(x => x.ViewModel)
+                    .BindTo(this, x => x.DataContext));
 
             // ReactiveUI.Validation: Bindings for error messages.
             // BindValidation(ViewModel, vmProperty, viewControlProperty)
             // This will bind the validation message for the specified property to the control property.
-            this.BindValidation(ViewModel, x => x.UserName, x => x.UserNameValidation.Text)
-                .DisposeWith(disposables);
-            this.BindValidation(ViewModel, x => x.Password, x => x.PasswordValidation.Text)
-                .DisposeWith(disposables);
-            this.BindValidation(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordValidation.Text)
-                .DisposeWith(disposables);
+            disposables.Add(this.BindValidation(ViewModel, x => x.UserName, x => x.UserNameValidation.Text));
+            disposables.Add(this.BindValidation(ViewModel, x => x.Password, x => x.PasswordValidation.Text));
+            disposables.Add(this.BindValidation(ViewModel, x => x.ConfirmPassword, x => x.ConfirmPasswordValidation.Text));
 
             // ReactiveUI.Validation: Compound validation bindings.
             // BindValidation(ViewModel, viewControlProperty)
             // This will bind all validation messages for the entire ViewModel to the control property.
             // We use a formatter to join multiple error messages with a new line.
-            this.BindValidation(ViewModel, x => x.CompoundValidation.Text, new SingleLineFormatter(Environment.NewLine))
-                .DisposeWith(disposables);
+            disposables.Add(this.BindValidation(ViewModel, x => x.CompoundValidation.Text, new SingleLineFormatter(Environment.NewLine)));
 
             // Controlling visibility of validation messages based on their content.
-            this.WhenAnyValue(x => x.UserNameValidation.Text, text => !string.IsNullOrWhiteSpace(text))
-                .BindTo(this, x => x.UserNameValidation.Visibility)
-                .DisposeWith(disposables);
-            this.WhenAnyValue(x => x.PasswordValidation.Text, text => !string.IsNullOrWhiteSpace(text))
-                .BindTo(this, x => x.PasswordValidation.Visibility)
-                .DisposeWith(disposables);
-            this.WhenAnyValue(x => x.ConfirmPasswordValidation.Text, text => !string.IsNullOrWhiteSpace(text))
-                .BindTo(this, x => x.ConfirmPasswordValidation.Visibility)
-                .DisposeWith(disposables);
+            disposables.Add(
+                this.WhenAnyValue(x => x.UserNameValidation.Text, text => !string.IsNullOrWhiteSpace(text))
+                    .BindTo(this, x => x.UserNameValidation.Visibility));
+            disposables.Add(
+                this.WhenAnyValue(x => x.PasswordValidation.Text, text => !string.IsNullOrWhiteSpace(text))
+                    .BindTo(this, x => x.PasswordValidation.Visibility));
+            disposables.Add(
+                this.WhenAnyValue(x => x.ConfirmPasswordValidation.Text, text => !string.IsNullOrWhiteSpace(text))
+                    .BindTo(this, x => x.ConfirmPasswordValidation.Visibility));
         });
     }
 }

--- a/src/samples/LoginApp/ViewModels/SignUpViewModel.cs
+++ b/src/samples/LoginApp/ViewModels/SignUpViewModel.cs
@@ -5,19 +5,20 @@
 
 using System;
 using System.Linq;
-using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
-using System.Reactive.Linq;
 using System.Threading.Tasks;
 using LoginApp.Services;
 using ReactiveUI;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Signals;
 using ReactiveUI.SourceGenerators;
 using ReactiveUI.Validation.Contexts;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 using ReactiveUI.Validation.States;
 using Splat;
+using Unit = ReactiveUI.Primitives.RxVoid;
 
 namespace LoginApp.ViewModels;
 
@@ -126,7 +127,7 @@ public partial class SignUpViewModel : ReactiveValidationObject, IRoutableViewMo
         var usernameValidated =
             this.WhenAnyValue(x => x.UserName)
                 .Throttle(TimeSpan.FromSeconds(0.7), RxSchedulers.TaskpoolScheduler)
-                .SelectMany(ValidateNameImpl)
+                .SelectMany(username => Signal.FromAsync(() => ValidateNameImpl(username)))
                 .ObserveOn(RxSchedulers.MainThreadScheduler);
 
         // State to show while validation is in progress.
@@ -137,12 +138,11 @@ public partial class SignUpViewModel : ReactiveValidationObject, IRoutableViewMo
         // Merge both states: "Please wait..." immediately, followed by the actual result.
         this.ValidationRule(
             vm => vm.UserName,
-            usernameValidated.Merge(usernameDirty));
+            Signal.Merge(usernameValidated, usernameDirty));
 
         // Use the validation state to drive a 'Busy' indicator.
-        _isBusy = usernameValidated
-            .Select(_ => false)
-            .Merge(usernameDirty.Select(_ => true))
+        _isBusy = Signal
+            .Merge(usernameValidated.Select(_ => false), usernameDirty.Select(_ => true))
             .ToProperty(this, x => x.IsBusy)
             .DisposeWith(_disposables);
     }

--- a/src/tests/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.DotNet10_0.verified.txt
+++ b/src/tests/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.DotNet10_0.verified.txt
@@ -109,7 +109,7 @@ namespace ReactiveUI.Validation.Components
 }
 namespace ReactiveUI.Validation.Contexts
 {
-    public interface IValidationContext : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable, System.Reactive.Disposables.ICancelable
+    public interface IValidationContext : ReactiveUI.IReactiveObject, ReactiveUI.Primitives.Disposables.IsDisposed, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable
     {
         System.IObservable<bool> Valid { get; }
         DynamicData.IObservableList<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }
@@ -118,10 +118,10 @@ namespace ReactiveUI.Validation.Contexts
         void Remove(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation);
         void RemoveMany(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> validations);
     }
-    public class ValidationContext : ReactiveUI.ReactiveObject, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, ReactiveUI.Validation.Contexts.IValidationContext, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable, System.Reactive.Disposables.ICancelable
+    public class ValidationContext : ReactiveUI.ReactiveObject, ReactiveUI.IReactiveObject, ReactiveUI.Primitives.Disposables.IsDisposed, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, ReactiveUI.Validation.Contexts.IValidationContext, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable
     {
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("WhenAnyValue may reference members that could be trimmed in AOT scenarios.")]
-        public ValidationContext(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public ValidationContext(ReactiveUI.Primitives.Concurrency.ISequencer? scheduler = null) { }
         public bool IsDisposed { get; }
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.IValidationText Text { get; }
@@ -250,7 +250,7 @@ namespace ReactiveUI.Validation.Helpers
     public abstract class ReactiveValidationObject : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo, System.IDisposable
     {
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("WhenAnyValue may reference members that could be trimmed in AOT scenarios.")]
-        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
+        protected ReactiveValidationObject(ReactiveUI.Primitives.Concurrency.ISequencer? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
         public bool HasErrors { get; }
         public ReactiveUI.Validation.Contexts.IValidationContext ValidationContext { get; }
         public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs>? ErrorsChanged;

--- a/src/tests/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.DotNet8_0.verified.txt
+++ b/src/tests/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.DotNet8_0.verified.txt
@@ -109,7 +109,7 @@ namespace ReactiveUI.Validation.Components
 }
 namespace ReactiveUI.Validation.Contexts
 {
-    public interface IValidationContext : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable, System.Reactive.Disposables.ICancelable
+    public interface IValidationContext : ReactiveUI.IReactiveObject, ReactiveUI.Primitives.Disposables.IsDisposed, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable
     {
         System.IObservable<bool> Valid { get; }
         DynamicData.IObservableList<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }
@@ -118,10 +118,10 @@ namespace ReactiveUI.Validation.Contexts
         void Remove(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation);
         void RemoveMany(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> validations);
     }
-    public class ValidationContext : ReactiveUI.ReactiveObject, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, ReactiveUI.Validation.Contexts.IValidationContext, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable, System.Reactive.Disposables.ICancelable
+    public class ValidationContext : ReactiveUI.ReactiveObject, ReactiveUI.IReactiveObject, ReactiveUI.Primitives.Disposables.IsDisposed, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, ReactiveUI.Validation.Contexts.IValidationContext, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable
     {
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("WhenAnyValue may reference members that could be trimmed in AOT scenarios.")]
-        public ValidationContext(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public ValidationContext(ReactiveUI.Primitives.Concurrency.ISequencer? scheduler = null) { }
         public bool IsDisposed { get; }
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.IValidationText Text { get; }
@@ -250,7 +250,7 @@ namespace ReactiveUI.Validation.Helpers
     public abstract class ReactiveValidationObject : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo, System.IDisposable
     {
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("WhenAnyValue may reference members that could be trimmed in AOT scenarios.")]
-        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
+        protected ReactiveValidationObject(ReactiveUI.Primitives.Concurrency.ISequencer? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
         public bool HasErrors { get; }
         public ReactiveUI.Validation.Contexts.IValidationContext ValidationContext { get; }
         public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs>? ErrorsChanged;

--- a/src/tests/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.DotNet9_0.verified.txt
+++ b/src/tests/ReactiveUI.Validation.Tests/API/ApiApprovalTests.ValidationProject.DotNet9_0.verified.txt
@@ -109,7 +109,7 @@ namespace ReactiveUI.Validation.Components
 }
 namespace ReactiveUI.Validation.Contexts
 {
-    public interface IValidationContext : ReactiveUI.IReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable, System.Reactive.Disposables.ICancelable
+    public interface IValidationContext : ReactiveUI.IReactiveObject, ReactiveUI.Primitives.Disposables.IsDisposed, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable
     {
         System.IObservable<bool> Valid { get; }
         DynamicData.IObservableList<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> Validations { get; }
@@ -118,10 +118,10 @@ namespace ReactiveUI.Validation.Contexts
         void Remove(ReactiveUI.Validation.Components.Abstractions.IValidationComponent validation);
         void RemoveMany(System.Collections.Generic.IEnumerable<ReactiveUI.Validation.Components.Abstractions.IValidationComponent> validations);
     }
-    public class ValidationContext : ReactiveUI.ReactiveObject, ReactiveUI.IReactiveObject, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, ReactiveUI.Validation.Contexts.IValidationContext, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable, System.Reactive.Disposables.ICancelable
+    public class ValidationContext : ReactiveUI.ReactiveObject, ReactiveUI.IReactiveObject, ReactiveUI.Primitives.Disposables.IsDisposed, ReactiveUI.Validation.Components.Abstractions.IValidationComponent, ReactiveUI.Validation.Contexts.IValidationContext, Splat.IEnableLogger, System.ComponentModel.INotifyPropertyChanged, System.ComponentModel.INotifyPropertyChanging, System.IDisposable
     {
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("WhenAnyValue may reference members that could be trimmed in AOT scenarios.")]
-        public ValidationContext(System.Reactive.Concurrency.IScheduler? scheduler = null) { }
+        public ValidationContext(ReactiveUI.Primitives.Concurrency.ISequencer? scheduler = null) { }
         public bool IsDisposed { get; }
         public bool IsValid { get; }
         public ReactiveUI.Validation.Collections.IValidationText Text { get; }
@@ -250,7 +250,7 @@ namespace ReactiveUI.Validation.Helpers
     public abstract class ReactiveValidationObject : ReactiveUI.ReactiveObject, ReactiveUI.Validation.Abstractions.IValidatableViewModel, System.ComponentModel.INotifyDataErrorInfo, System.IDisposable
     {
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("WhenAnyValue may reference members that could be trimmed in AOT scenarios.")]
-        protected ReactiveValidationObject(System.Reactive.Concurrency.IScheduler? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
+        protected ReactiveValidationObject(ReactiveUI.Primitives.Concurrency.ISequencer? scheduler = null, ReactiveUI.Validation.Formatters.Abstractions.IValidationTextFormatter<string>? formatter = null) { }
         public bool HasErrors { get; }
         public ReactiveUI.Validation.Contexts.IValidationContext ValidationContext { get; }
         public event System.EventHandler<System.ComponentModel.DataErrorsChangedEventArgs>? ErrorsChanged;

--- a/src/tests/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
+++ b/src/tests/ReactiveUI.Validation.Tests/Models/IndeiTestViewModel.cs
@@ -3,7 +3,7 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Concurrency;
+using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Validation.Formatters.Abstractions;
 using ReactiveUI.Validation.Helpers;
 
@@ -19,7 +19,7 @@ public class IndeiTestViewModel : ReactiveValidationObject
     /// Initializes a new instance of the <see cref="IndeiTestViewModel"/> class.
     /// </summary>
     public IndeiTestViewModel()
-        : base(ImmediateScheduler.Instance)
+        : base(ImmediateSequencer.Instance)
     {
     }
 
@@ -28,7 +28,7 @@ public class IndeiTestViewModel : ReactiveValidationObject
     /// </summary>
     /// <param name="formatter">Validation text formatter.</param>
     public IndeiTestViewModel(IValidationTextFormatter<string> formatter)
-        : base(ImmediateScheduler.Instance, formatter)
+        : base(ImmediateSequencer.Instance, formatter)
     {
     }
 

--- a/src/tests/ReactiveUI.Validation.Tests/Models/SourceDestinationViewModel.cs
+++ b/src/tests/ReactiveUI.Validation.Tests/Models/SourceDestinationViewModel.cs
@@ -4,7 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Reactive.Concurrency;
+using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Contexts;
 
@@ -38,5 +38,5 @@ public class SourceDestinationViewModel : ReactiveObject, IValidatableViewModel
     } = new();
 
     /// <inheritdoc/>
-    public IValidationContext ValidationContext { get; } = new ValidationContext(Scheduler.Immediate);
+    public IValidationContext ValidationContext { get; } = new ValidationContext(ImmediateSequencer.Instance);
 }

--- a/src/tests/ReactiveUI.Validation.Tests/Models/TestViewModel.cs
+++ b/src/tests/ReactiveUI.Validation.Tests/Models/TestViewModel.cs
@@ -4,8 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
+using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Contexts;
 using ReactiveUI.Validation.Helpers;
@@ -45,5 +45,5 @@ public class TestViewModel : ReactiveObject, IValidatableViewModel
     }
 
     /// <inheritdoc/>
-    public IValidationContext ValidationContext { get; } = new ValidationContext(ImmediateScheduler.Instance);
+    public IValidationContext ValidationContext { get; } = new ValidationContext(ImmediateSequencer.Instance);
 }

--- a/src/tests/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
+++ b/src/tests/ReactiveUI.Validation.Tests/ObservableValidationTests.cs
@@ -89,6 +89,20 @@ public class ObservableValidationTests
     }
 
     /// <summary>
+    /// Verifies that a null observable is rejected by the constructor overload that builds validation states.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task NullObservableThrowsArgumentNullException()
+    {
+        await Assert.That(() => new ObservableValidation<TestViewModel, bool>(
+            _validModel,
+            null!,
+            valid => valid,
+            "broken")).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>
     /// Verifies if the observable returns invalid.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/src/tests/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
+++ b/src/tests/ReactiveUI.Validation.Tests/ValidationBindingTests.cs
@@ -5,10 +5,10 @@
 
 using System;
 using System.Linq;
-using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
+using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Components;
 using ReactiveUI.Validation.Contexts;
@@ -386,7 +386,7 @@ public class ValidationBindingTests
 
         await Assert.That(view.ViewModel).IsNotNull();
 
-        using var outerContext = new ValidationContext(ImmediateScheduler.Instance);
+        using var outerContext = new ValidationContext(ImmediateSequencer.Instance);
         using var validation = new BasePropertyValidation<TestViewModel, string>(
             view.ViewModel!,
             vm => vm.Name,

--- a/src/tests/ReactiveUI.Validation.Tests/ValidationContextTests.cs
+++ b/src/tests/ReactiveUI.Validation.Tests/ValidationContextTests.cs
@@ -3,8 +3,7 @@
 // The ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Reactive.Concurrency;
-
+using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Validation.Abstractions;
 using ReactiveUI.Validation.Collections;
 using ReactiveUI.Validation.Components;
@@ -26,7 +25,7 @@ public class ValidationContextTests
     [Test]
     public async Task EmptyValidationContextIsValid()
     {
-        using var vc = new ValidationContext(ImmediateScheduler.Instance);
+        using var vc = new ValidationContext(ImmediateSequencer.Instance);
 
         using (Assert.Multiple())
         {
@@ -42,7 +41,7 @@ public class ValidationContextTests
     [Test]
     public async Task CanAddValidationComponentsTest()
     {
-        using var vc = new ValidationContext(ImmediateScheduler.Instance);
+        using var vc = new ValidationContext(ImmediateSequencer.Instance);
 
         var invalidName = string.Empty;
 
@@ -78,7 +77,7 @@ public class ValidationContextTests
         const string validName = "valid";
         var invalidName = string.Empty;
 
-        using var vc = new ValidationContext(ImmediateScheduler.Instance);
+        using var vc = new ValidationContext(ImmediateSequencer.Instance);
 
         var vm = new TestViewModel { Name = validName, Name2 = validName };
 
@@ -246,7 +245,7 @@ public class ValidationContextTests
     [Test]
     public async Task IsDisposedReflectsContextState()
     {
-        var vc = new ValidationContext(ImmediateScheduler.Instance);
+        var vc = new ValidationContext(ImmediateSequencer.Instance);
 
         await Assert.That(vc.IsDisposed).IsFalse();
 
@@ -320,7 +319,7 @@ public class ValidationContextTests
     [Test]
     public async Task BuildTextReturnsNoneWhenNoComponents()
     {
-        using var vc = new ValidationContext(ImmediateScheduler.Instance);
+        using var vc = new ValidationContext(ImmediateSequencer.Instance);
 
         var result = vc.BuildText();
 
@@ -334,7 +333,7 @@ public class ValidationContextTests
     [Test]
     public async Task BuildTextReturnsSingleInvalidComponentText()
     {
-        using var vc = new ValidationContext(ImmediateScheduler.Instance);
+        using var vc = new ValidationContext(ImmediateSequencer.Instance);
         var vm = new TestViewModel { Name = string.Empty };
 
         using var validation = new BasePropertyValidation<TestViewModel, string>(
@@ -364,7 +363,7 @@ public class ValidationContextTests
     [Test]
     public async Task BuildTextReturnsCombinedTextForMultipleInvalidComponents()
     {
-        using var vc = new ValidationContext(ImmediateScheduler.Instance);
+        using var vc = new ValidationContext(ImmediateSequencer.Instance);
         var vm = new TestViewModel { Name = string.Empty };
 
         using var validation1 = new BasePropertyValidation<TestViewModel, string>(
@@ -402,7 +401,7 @@ public class ValidationContextTests
     [Test]
     public async Task BuildTextReturnsNoneWhenAllValid()
     {
-        using var vc = new ValidationContext(ImmediateScheduler.Instance);
+        using var vc = new ValidationContext(ImmediateSequencer.Instance);
         var vm = new TestViewModel { Name = "valid" };
 
         using var validation = new BasePropertyValidation<TestViewModel, string>(
@@ -428,7 +427,7 @@ public class ValidationContextTests
     [Test]
     public async Task ActivateIsIdempotent()
     {
-        using var vc = new ValidationContext(ImmediateScheduler.Instance);
+        using var vc = new ValidationContext(ImmediateSequencer.Instance);
 
         vc.Activate();
         vc.Activate();
@@ -469,7 +468,7 @@ public class ValidationContextTests
         /// <summary>
         /// Backing field for the validation context; can be nullified for testing.
         /// </summary>
-        private IValidationContext _context = new ValidationContext(ImmediateScheduler.Instance);
+        private IValidationContext _context = new ValidationContext(ImmediateSequencer.Instance);
 
         /// <summary>
         /// Gets or sets the name property used in validation rules.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / migration update for the ReactiveUI.Validation move to ReactiveUI.Primitives-based ReactiveUI packages.

## What is the new behavior?

- ReactiveUI.Validation builds against the primitives scheduler/disposable surface while keeping DynamicData/System.Reactive interop localized.
- WPF and WinForms samples use primitives `MultipleDisposable` activation registration.
- Avalonia samples no longer depend on the stale `ReactiveUI.Avalonia` bridge; the login sample uses Avalonia bindings with direct validation context subscriptions.
- Test scheduler usage and API approval snapshots are aligned with the primitives public API surface.

## What is the current behavior?

The solution fails to build after the ReactiveUI update because some code still assumes System.Reactive scheduler/disposable APIs and stale platform adapter behavior. API approvals also reflect the old scheduler/disposable public shape.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation performed from `src`:

- `dotnet build ReactiveUI.Validation.slnx -c Release`
- `dotnet test --solution ReactiveUI.Validation.slnx -c Release`
- `dotnet test --project tests/ReactiveUI.Validation.Tests/ReactiveUI.Validation.Tests.csproj -c Release -- --coverage --coverage-output-format cobertura --disable-logo --no-progress`

The MTP coverage report for net10 reported 99.85% line coverage and 99.64% branch coverage.